### PR TITLE
Fix some broken links.

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -134,7 +134,7 @@
 
         <div class="header-override">
           <p>
-            <a href="http://moveit.ros.org/research">MoveIt! Website</a><br/>
+            <a href="http://moveit.ros.org">MoveIt! Website</a><br/>
             <a href="http://moveit.ros.org/blog">Blog</a>
           </p>
           <a href="http://moveit.ros.org">

--- a/doc/ros_visualization/joystick.rst
+++ b/doc/ros_visualization/joystick.rst
@@ -24,7 +24,7 @@ This script can read three types of joy sticks:
 
 1. XBox360 Controller via USB
 2. PS3 Controller via USB
-3. PS3 Contrlller via Bluetooth (Please use ps3joy package <http://wiki.ros.org/ps3joy>)
+3. PS3 Controller via Bluetooth (Please use ps3joy package at `http://wiki.ros.org/ps3joy <http://wiki.ros.org/ps3joy>`_)
 
 Joystick Command Mappings
 -------------------------

--- a/doc/ros_visualization/visualization_tutorial.rst
+++ b/doc/ros_visualization/visualization_tutorial.rst
@@ -10,7 +10,7 @@ Pre-requisites
 ---------------
 
 You should have completed the `MoveIt! Setup Assistant tutorial
-<http://docs.ros.org/api/moveit_setup_assistant/html/doc/tutorial.html>`_
+<../setup_assistant/setup_assistant_tutorial.html>`_
 and you should now have a MoveIt! configuration for the PR2 that you
 can use.  This tutorial assumes the generated MoveIt! configuration
 package is called "pr2_moveit_config".

--- a/doc/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/setup_assistant/setup_assistant_tutorial.rst
@@ -119,8 +119,7 @@ Add the right arm
 
   * Choose *kdl_kinematics_plugin/KDLKinematicsPlugin* as the
     kinematics solver. *Note: if you have a custom robot and would
-    like a powerful custom IK solver, see
-    `Kinematics/IKFast<http://moveit.ros.org/wiki/Kinematics/IKFast>`_*
+    like a powerful custom IK solver, see `Kinematics/IKFast <../ikfast_tutorial.html>`_ *
 
   * Let *Kin. Search Resolution* and *Kin. Search Timeout* stay at
     their default values.
@@ -277,13 +276,13 @@ The MoveIt! Rviz plugin
 
 * Start looking at how you can use the generated configuration files
   to play with MoveIt! using the
-  `MoveIt! Rviz Plugin <http://moveit.ros.org/wiki/PR2/Rviz_Plugin/Quick_Start>`_.
+  `MoveIt! Rviz Plugin <../ros_visualization/visualization_tutorial.html>`_.
 
 Setup IKFast Inverse Kinematics Solver
 
 * A faster IK solver than the default KDL solver, but takes some
   additional steps to setup:
-  `Kinematics/IKFast <http://moveit.ros.org/wiki/Kinematics/IKFast>`_
+  `Kinematics/IKFast <../ikfast_tutorial.html>`_
 
 Additional Reading
 ---------------------


### PR DESCRIPTION
The majority of the links don't work because of links of type http://docs.ros.org/api/ don't exist currently. For a temporary fix, see my other pull request.

Links I was not able to fix because either the target exists no longer or I was unable to find it:

file: doc/ros_visualization/visualization_tutorial.rst
Link http://moveit.ros.org/wiki/PR2/Gazebo/Quick_Start ,
possible link target: http://wiki.ros.org/pr2_simulator/Tutorials/StartingPR2Simulation

file: doc/pr2_tutorials/kinematics/src/doc/kinematics_tutorial.rst
link http://moveit.ros.org/wiki/RobotStateDisplay/C%2B%2B_API

file dec/setup_assistant/setup_assistant_tutorial.rst
link http://moveit.ros.org/wiki/SRDF and http://moveit.ros.org/wiki/URDF

file doc/pr2_tutorials/planning/src/doc/planning_scene_ros_api_tutorial.rst
link https://github.com/ros-planning/moveit_pr2/blob/hydro-devel/moveit_tutorials/planning/launch/planning_scene_ros_api_tutorial.launch

All links pointing to a file in a subdirectory of https://github.com/ros-planning/moveit_pr2/blob/hydro-devel. Files containing such links:

doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
doc/pr2_tutorials/planning/src/doc/motion_planning_api_tutorial.rst
doc/pr2_tutorials/planning/src/doc/move_group_interface_tutorial.rst
doc/pr2_tutorials/planning/src/doc/planning_scene_tutorial.rst
doc/pr2_tutorials/planning/src/doc/planning_scene_ros_api_tutorial.rst
doc/pr2_tutorials/planning/src/doc/planning_pipeline_tutorial.rst
doc/pr2_tutorials/planning/scripts/doc/move_group_python_interface_tutorial.rst
