### PR TITLE
Right-align 'Edit on GitHub' button

### DIFF
--- a/_static/override.css
+++ b/_static/override.css
@@ -13,3 +13,10 @@
 .header-override img {
   width: 200px;
 }
+
+.wy-breadcrumbs li.wy-breadcrumbs-aside {
+  display: block;
+  width: 100%;
+  text-align: right;
+  margin-bottom: -25px;
+}

--- a/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -1,23 +1,23 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
+    <li class="wy-breadcrumbs-aside">
+      {% if pagename != "search" %}
+        {% if display_github %}
+          <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-github"> Edit on GitHub</a>
+        {% elif display_bitbucket %}
+          <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-bitbucket"> Edit on Bitbucket</a>
+        {% elif show_source and source_url_prefix %}
+          <a href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">View page source</a>
+        {% elif show_source and has_source and sourcename %}
+          <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
+        {% endif %}
+      {% endif %}
+    </li>
     <li><a href="{{ pathto(master_doc) }}">Docs</a> &raquo;</li>
       {% for doc in parents %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
       {% endfor %}
     <li>{{ title }}</li>
-      <li class="wy-breadcrumbs-aside">
-        {% if pagename != "search" %}
-          {% if display_github %}
-            <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-github"> Edit on GitHub</a>
-          {% elif display_bitbucket %}
-            <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-bitbucket"> Edit on Bitbucket</a>
-          {% elif show_source and source_url_prefix %}
-            <a href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">View page source</a>
-          {% elif show_source and has_source and sourcename %}
-            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
-          {% endif %}
-        {% endif %}
-      </li>
   </ul>
   <hr/>
 </div>


### PR DESCRIPTION
@davetcoleman you asked me about this a few days ago but I got distracted.

Looks like there is quite a lot of autogenerated CSS in `theme.css` which I'd rather not hand-edit, so I made the change in `override.css`.

## Before

![image](https://cloud.githubusercontent.com/assets/556340/18074476/ad038c14-6e21-11e6-82c7-8d33e5da3233.png)

## After

![image](https://cloud.githubusercontent.com/assets/556340/18074480/b392bb68-6e21-11e6-813a-5a89ffcc92a7.png)
