### PR TITLE
Update hydro to indigo for tutorials that use PR2.

### DIFF
--- a/doc/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/setup_assistant/setup_assistant_tutorial.rst
@@ -40,7 +40,7 @@ Step 1: Start
   installed when you installed ros-indigo-moveit-full-pr2. (This file
   gets installed in
   /opt/ros/indigo/share/pr2_description/robots/pr2.urdf.xacro on Ubuntu
-  with ROS Hydro.)  Choose that file and then click *Load Files*. The
+  with ROS Indigo.)  Choose that file and then click *Load Files*. The
   Setup Assistant will load the files (this might take a few seconds)
   and present you with this screen:
 


### PR DESCRIPTION
- Just found that many tutorial pages that use PR2 still refer to the removed folder `moveit_pr2/blob/hydro-devel/moveit_tutorials`.
- With active LTS indigo, EOLed hydro shouldn't be used wherever possible.