### PR TITLE
add missing scoped_ptr include

### DIFF
--- a/doc/pr2_tutorials/planning/src/motion_planning_api_tutorial.cpp
+++ b/doc/pr2_tutorials/planning/src/motion_planning_api_tutorial.cpp
@@ -45,6 +45,8 @@
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit_msgs/PlanningScene.h>
 
+#include <boost/scoped_ptr.hpp>
+
 int main(int argc, char **argv)
 {
   ros::init (argc, argv, "move_group_tutorial");


### PR DESCRIPTION
the code uses a boost::scoped_ptr below.

While this is a stylistic fix in indigo, this produces a failure in kinetic.
The moveit headers do not provided that class anymore.