### PR TITLE
get joint_names from getVariableNames instead of getJointModelNames

### DIFF
--- a/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
+++ b/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
   kinematic_state->setToDefaultValues();
   const robot_state::JointModelGroup *joint_model_group = kinematic_model->getJointModelGroup("right_arm");
 
-  const std::vector<std::string> &joint_names = joint_model_group->getJointModelNames();
+  const std::vector<std::string> &joint_names = joint_model_group->getVariableNames();
 
   // Get Joint Values
   // ^^^^^^^^^^^^^^^^

--- a/doc/pr2_tutorials/planning/src/move_group_interface_tutorial.cpp
+++ b/doc/pr2_tutorials/planning/src/move_group_interface_tutorial.cpp
@@ -242,9 +242,9 @@ int main(int argc, char **argv)
   waypoints.push_back(start_pose2);
 
   geometry_msgs::Pose target_pose3 = start_pose2;
-  target_pose3.position.x += 0.2;
+
   target_pose3.position.z += 0.2;
-  waypoints.push_back(target_pose3);  // up and out
+  waypoints.push_back(target_pose3);  // up 
 
   target_pose3.position.y -= 0.1;
   waypoints.push_back(target_pose3);  // left
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
   target_pose3.position.z -= 0.2;
   target_pose3.position.y += 0.2;
   target_pose3.position.x -= 0.2;
-  waypoints.push_back(target_pose3);  // down and right (back to start)
+  waypoints.push_back(target_pose3);  // down and right 
 
   // Cartesian motions are frequently needed to be slower for actions such as approach and retreat
   // grasp motions. Here we demonstrate how to reduce the speed of the robot arm via a scaling factor

--- a/doc/pr2_tutorials/planning/src/move_group_interface_tutorial.cpp
+++ b/doc/pr2_tutorials/planning/src/move_group_interface_tutorial.cpp
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
   // and report success on execution of a trajectory.
 
   /* Uncomment below line when working with a real robot */
-  /* group.move() */
+  /* move_group.move() */
 
   // Planning to a joint-space goal
   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -242,6 +242,7 @@ int main(int argc, char **argv)
   waypoints.push_back(start_pose2);
 
   geometry_msgs::Pose target_pose3 = start_pose2;
+  target_pose3.position.x += 0.2;
   target_pose3.position.z += 0.2;
   waypoints.push_back(target_pose3);  // up and out
 


### PR DESCRIPTION
because copyJointGroupPositions call getVariableCount and getVariableIndexList.
It give different result if group has fixed joint.