### PR TITLE
get joint_names from getVariableNames() instead of getJointModelNames()

### DIFF
--- a/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
+++ b/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
   kinematic_state->setToDefaultValues();
   const robot_state::JointModelGroup *joint_model_group = kinematic_model->getJointModelGroup("right_arm");
 
-  const std::vector<std::string> &joint_names = joint_model_group->getJointModelNames();
+  const std::vector<std::string> &joint_names = joint_model_group->getVariableNames();
 
   // Get Joint Values
   // ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
because copyJointGroupPositions call getVariableCount() and getVariableIndexList()