### PR TITLE
[move group py] Indigo issue is closed 

### DIFF
--- a/doc/pr2_tutorials/planning/scripts/doc/move_group_python_interface_tutorial.rst
+++ b/doc/pr2_tutorials/planning/scripts/doc/move_group_python_interface_tutorial.rst
@@ -34,9 +34,6 @@ Now run the python code directly using rosrun::
 
  rosrun moveit_tutorials move_group_python_interface_tutorial.py
 
-Please note that due to a bug in ros-Indigo discussed in issue `#15 <https://github.com/ros-planning/moveit_commander/issues/15>`_ the moveit_commander throws an exception when shutting down.
-This does not interfere with the functioning of the code itself.
-
 Expected Output
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
In [tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/pr2_tutorials/planning/scripts/doc/move_group_python_interface_tutorial.html#running-the-code):
> Please note that due to a bug in ros-Indigo discussed in issue https://github.com/ros-planning/moveit_commander/issues/15 the moveit_commander throws an exception when shutting down. This does not interfere with the functioning of the code itself.

This issue is closed already https://github.com/ros-planning/moveit_commander/issues/15#issuecomment-235528783