### PR TITLE
[python] Add queue_size arg for rospy.Publisher.

### DIFF
--- a/doc/pr2_tutorials/planning/scripts/move_group_python_interface_tutorial.py
+++ b/doc/pr2_tutorials/planning/scripts/move_group_python_interface_tutorial.py
@@ -80,7 +80,8 @@ def move_group_python_interface_tutorial():
   ## trajectories for RVIZ to visualize.
   display_trajectory_publisher = rospy.Publisher(
                                       '/move_group/display_planned_path',
-                                      moveit_msgs.msg.DisplayTrajectory)
+                                      moveit_msgs.msg.DisplayTrajectory,
+                                      queue_size=20)
 
   ## Wait for RVIZ to initialize. This sleep is ONLY to allow Rviz to come up.
   print "============ Waiting for RVIZ..."


### PR DESCRIPTION
For [py tutorial](http://docs.ros.org/api/moveit_tutorials/html/doc/pr2_tutorials/planning/scripts/doc/move_group_python_interface_tutorial.html),

without `queue_size` arg, the following warning occurs, which can confuse tutorial readers.

```
In [21]: display_trajectory_publisher = rospy.Publisher(
   ....:                                     '/move_group/display_planned_path',
   ....:                                     moveit_msgs.msg.DisplayTrajectory)
/usr/bin/ipython:3: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
```

I'm not sure if `queue_size=20` is enough though.