### PR TITLE
[html layout] Suggest tutorial readers to download code of moveit_tutorials

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -149,7 +149,13 @@
 
             <div class="admonition note">
               <p class="first admonition-title">Outdated Documentation</p>
-              <p class="last">This is the old Indigo tutorials, the latest can be found <a href="http://docs.ros.org/kinetic/api/moveit_tutorials/html/">here for Kinetic</a></p>
+              <p class="last">This is the old Indigo tutorials, the latest can be found <a href="http://docs.ros.org/kinetic/api/moveit_tutorials/html/">here for Kinetic</a>.<br />
+                The code used in this tutorial can be found at <a href = "https://github.com/ros-planning/moveit_tutorials">moveit_tutorials repository</a> (see into doc folder). You can also download the source to your computer by:<br />
+                <code>
+                git clone https://github.com/ros-planning/moveit_tutorials && cd moveit_tutorials/doc<br />
+                git checkout indigo-devel<br />
+                </code>
+              </p>
             </div>
 
             {% block body %}{% endblock %}


### PR DESCRIPTION
In https://github.com/ros-planning/moveit_tutorials/pull/64 we noticed that some tutorial resources are duplicated, in the form of source and binary. We will want to only use source and https://github.com/ros-planning/moveit_tutorials as a single location to maintain all tutorial resource.

This PR tries to show "note" section at the top of every tutorial page to suggest users to clone the source.

@v4hn please review. Hope this is close to the solution what we're discussing in #64.

UPDATE: This can be portable to kinetic-devel with modifying one git command.