### PR TITLE
fixed links to dcoleman github causing build to fail

### DIFF
--- a/doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
+++ b/doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
@@ -10,7 +10,7 @@ In this section, we will walk through configuring the 3D sensors on your robot w
 YAML Configuration file (Point Cloud)
 -------------------------------------
 
-We will have to generate a YAML configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_depthmap.yaml>`_. ::
+We will have to generate a YAML configuration file for configuring the 3D sensors. Please see `this example file <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_depthmap.yaml>`_ for processing point clouds, located in the `pr2_moveit_config repository for Kinetic <https://github.com/davetcoleman/pr2_moveit_config>`_. ::
 
  sensors:
    - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
@@ -43,7 +43,7 @@ We will have to generate a YAML configuration file for configuring the 3D sensor
 YAML Configuration file (Depth Map)
 -----------------------------------
 
-We will have to generate a rgbd.yaml configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_pointcloud.yaml>`_ ::
+We will have to generate a rgbd.yaml configuration file for configuring the 3D sensors. An `example file for processing point clouds <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_pointcloud.yaml>`_ can be found in the `pr2_moveit_config repo <https://github.com/davetcoleman/pr2_moveit_config>`_ as well ::
 
  sensors:
    - sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater

--- a/doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
+++ b/doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
@@ -10,7 +10,7 @@ In this section, we will walk through configuring the 3D sensors on your robot w
 YAML Configuration file (Point Cloud)
 -------------------------------------
 
-We will have to generate a YAML configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/config/sensors_kinect_depthmap.yaml>`_. ::
+We will have to generate a YAML configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_depthmap.yaml>`_. ::
 
  sensors:
    - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
@@ -43,7 +43,7 @@ We will have to generate a YAML configuration file for configuring the 3D sensor
 YAML Configuration file (Depth Map)
 -----------------------------------
 
-We will have to generate a rgbd.yaml configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/config/sensors_kinect_pointcloud.yaml>`_ ::
+We will have to generate a rgbd.yaml configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_pointcloud.yaml>`_ ::
 
  sensors:
    - sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater

--- a/doc/ros_visualization/visualization_tutorial.rst
+++ b/doc/ros_visualization/visualization_tutorial.rst
@@ -96,7 +96,7 @@ The display states for each of these visualizations can be toggled on and off us
 Step 3: Interact with the PR2
 -----------------------------
 
-  * Press **Interact** in the top menu of rviz (Note: some tools may be
+* Press **Interact** in the top menu of rviz (Note: some tools may be
   hidden, press **+** in the top menu to add the **Interact** tool. 
   You should see a couple of interactive markers appear for the 
   right arm of the PR2.


### PR DESCRIPTION
I was trying to fix #96 and *swear* that Travis Cl complained due to bad links in `perception_configuration.rst`, so I looked around and found that #101 added links to non-existent github pages.

I think the below is what was intended, but now my build on #96 is failing for a different reason! Nevertheless, these are still wrong on the live docs, so I think this is still a good change to make.