### PR TITLE
Re-added interact button image to visualization tutorial

### DIFF
--- a/doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
+++ b/doc/pr2_tutorials/planning/src/doc/perception_configuration.rst
@@ -10,7 +10,7 @@ In this section, we will walk through configuring the 3D sensors on your robot w
 YAML Configuration file (Point Cloud)
 -------------------------------------
 
-We will have to generate a YAML configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/config/sensors_kinect_depthmap.yaml>`_. ::
+We will have to generate a YAML configuration file for configuring the 3D sensors. Please see `this example file <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_depthmap.yaml>`_ for processing point clouds, located in the `pr2_moveit_config repository for Kinetic <https://github.com/davetcoleman/pr2_moveit_config>`_. ::
 
  sensors:
    - sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater
@@ -43,7 +43,7 @@ We will have to generate a YAML configuration file for configuring the 3D sensor
 YAML Configuration file (Depth Map)
 -----------------------------------
 
-We will have to generate a rgbd.yaml configuration file for configuring the 3D sensors. An example file for processing point clouds can be found in the `pr2_moveit_config directory for Kinetic <https://github.com/davetcoleman/pr2_moveit_config/config/sensors_kinect_pointcloud.yaml>`_ ::
+We will have to generate a rgbd.yaml configuration file for configuring the 3D sensors. An `example file for processing point clouds <https://github.com/davetcoleman/pr2_moveit_config/blob/master/config/sensors_kinect_pointcloud.yaml>`_ can be found in the `pr2_moveit_config repo <https://github.com/davetcoleman/pr2_moveit_config>`_ as well ::
 
  sensors:
    - sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater

--- a/doc/ros_visualization/visualization_tutorial.rst
+++ b/doc/ros_visualization/visualization_tutorial.rst
@@ -97,7 +97,7 @@ Step 3: Interact with the PR2
 -----------------------------
 
 * Press **Interact** in the top menu of rviz (Note: some tools may be
-  hidden, press **+** in the top menu to add the **Interact** tool. 
+  hidden, press **+** in the top menu to add the **Interact** tool as shown below). 
   You should see a couple of interactive markers appear for the 
   right arm of the PR2.
 
@@ -110,6 +110,9 @@ Step 3: Interact with the PR2
     * You will be able to use these markers (which are attached to the
       tip link of each arm) to drag the arm around and change its
       orientation.
+
+.. image:: rviz_interact_button.png
+   :width: 250px
 
 .. image:: rviz_plugin_interact.png
    :width: 500px

--- a/doc/ros_visualization/visualization_tutorial.rst
+++ b/doc/ros_visualization/visualization_tutorial.rst
@@ -96,7 +96,7 @@ The display states for each of these visualizations can be toggled on and off us
 Step 3: Interact with the PR2
 -----------------------------
 
-  * Press **Interact** in the top menu of rviz (Note: some tools may be
+* Press **Interact** in the top menu of rviz (Note: some tools may be
   hidden, press **+** in the top menu to add the **Interact** tool. 
   You should see a couple of interactive markers appear for the 
   right arm of the PR2.

--- a/doc/ros_visualization/visualization_tutorial.rst
+++ b/doc/ros_visualization/visualization_tutorial.rst
@@ -21,7 +21,7 @@ have a workspace for this tutorial create one below. Otherwise continue
 to sourcing::
 
   mkdir -p ~/ws_moveit/src
-  cd ~/ws_moveit/src
+  cd ~/ws_moveit
   catkin build
 
 Source and Build the moveit_config package


### PR DESCRIPTION
If helpful, re-added an image on how to add the `Interact` button if it didn't appear. This was originally added in #91 but was overwritten/reverted in #92. Committing to this branch didn't re-trigger the original build, so I think I need to re-PR.