### PR TITLE
Changed directory to solve catkin not building

### DIFF
--- a/doc/ros_visualization/visualization_tutorial.rst
+++ b/doc/ros_visualization/visualization_tutorial.rst
@@ -21,7 +21,7 @@ have a workspace for this tutorial create one below. Otherwise continue
 to sourcing::
 
   mkdir -p ~/ws_moveit/src
-  cd ~/ws_moveit/src
+  cd ~/ws_moveit
   catkin build
 
 Source and Build the moveit_config package


### PR DESCRIPTION
Changed goal directory from ``~/ws_moveit/src`` to ``~/ws_moveit`` in order to make catkin successfully build when teaching how to source MoveIt! configuration for the PR2.