### PR TITLE
[setup_assistant_tutorial] makes step 8 explicit

### DIFF
--- a/doc/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/setup_assistant/setup_assistant_tutorial.rst
@@ -247,11 +247,15 @@ directly controlled. The PR2 does not have any passive
 joints so we will skip this step.
 
 Step 8: Add Author Information
+------------------------------
 
-* catkin requires author information for publishing purposes. You can
-  enter your name and email address in the *Author Information* pane.
+Catkin requires author information for publishing purposes
 
-Step 8: Generate Configuration Files
+* Click on the *Author Information* pane.
+* Enter your name and email address.
+
+
+Step 9: Generate Configuration Files
 ------------------------------------
 
 You are almost there. One last step - generating all the configuration


### PR DESCRIPTION
minor reading fix in step 8 and 9 in `setup_assistant_tutorial`.

Though this Author pane is missing in the pictures (I'm assuming this was added in kinetic), those can be updated also (in this PR or separately) if required.