### PR TITLE
Update the tutorials for Python API to fix consistent duplicate point errors.

### DIFF
--- a/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
+++ b/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
@@ -43,7 +43,7 @@
 
 int main(int argc, char **argv)
 {
-  ros::init(argc, argv, "right_arm_kinematics");
+  ros::init(argc, argv, "UR10_arm_kinematics");
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
@@ -70,16 +70,10 @@ int main(int argc, char **argv)
   robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
   ROS_INFO("Model frame: %s", kinematic_model->getModelFrame().c_str());
 
-  // Using the :moveit_core:`RobotModel`, we can construct a
-  // :moveit_core:`RobotState` that maintains the configuration
-  // of the robot. We will set all joints in the state to their
-  // default values. We can then get a
-  // :moveit_core:`JointModelGroup`, which represents the robot
-  // model for a particular group, e.g. the "right_arm" of the PR2
-  // robot.
+
   robot_state::RobotStatePtr kinematic_state(new robot_state::RobotState(kinematic_model));
   kinematic_state->setToDefaultValues();
-  const robot_state::JointModelGroup *joint_model_group = kinematic_model->getJointModelGroup("right_arm");
+  const robot_state::JointModelGroup *joint_model_group = kinematic_model->getJointModelGroup("manipulator");
 
   const std::vector<std::string> &joint_names = joint_model_group->getVariableNames();
 

--- a/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
+++ b/doc/pr2_tutorials/kinematics/src/kinematic_model_tutorial.cpp
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
   // "r_wrist_roll_link" which is the most distal link in the
   // "right_arm" of the robot.
   kinematic_state->setToRandomPositions(joint_model_group);
-  const Eigen::Affine3d &end_effector_state = kinematic_state->getGlobalLinkTransform("r_wrist_roll_link");
+  const Eigen::Affine3d &end_effector_state = kinematic_state->getGlobalLinkTransform("ee_link");
 
   /* Print end-effector pose. Remember that this is in the model frame */
   ROS_INFO_STREAM("Translation: " << end_effector_state.translation());


### PR DESCRIPTION
This PR is in conjunction with this current PR:

https://github.com/ros-planning/moveit/pull/737

I have updated the tutorials because of a consistent issue I was facing when following it with the Python API. 

When you attempt to plan a cartesian path following the Python API, you will often receive an error like this:  

`[ERROR] [1515384240.163191133, 270.462000000]: Trajectory message contains waypoints that are not strictly increasing in time.` 

Further investigation has shown that the cause of the issue is that in the tutorial, you append the starting point of the end effector into the `waypoints[]` list, so when the planner tries to plan to that waypoint, it sees that it will reach that position in 0 time and append that to the resultant path. This non-monotonic increase in the time causes the controller to throw this error because the waypoints are not unique in the timestamp.

I have added a warning in the planner in the above PR, and updated the tutorial to allow for better educational experiences and knowledge transfer to new/returning users of the Python API.
