### PR TITLE
removed joy as build dependency in cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(catkin REQUIRED
   COMPONENTS
     moveit_core
     moveit_visual_tools
-    joy
     moveit_ros_planning
     moveit_ros_planning_interface
     pluginlib
@@ -35,7 +34,6 @@ catkin_package(
   CATKIN_DEPENDS
     moveit_core
     moveit_visual_tools
-    joy
     moveit_ros_planning_interface
     interactive_markers
   DEPENDS


### PR DESCRIPTION
https://github.com/PickNikRobotics/moveit_tutorials/pull/53 added `joy` as an additional build dependency to the `CMakeFile`, but not to the `package.xml`. There it was only mentioned as a run-dependency (which makes sense). As there is no need to have joy available during building, I removed joy from the cmake file again as the [Melodic build complains](https://travis-ci.org/ros-planning/moveit/jobs/379624211) after @davetcoleman added the tutorials to `moveit.rosinstall` in https://github.com/ros-planning/moveit/pull/892.