### PR TITLE
Corrected tutorial's Cartesian path example

### DIFF
--- a/doc/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/move_group_interface/move_group_interface_tutorial.rst
@@ -32,7 +32,7 @@ See the `YouTube video <https://youtu.be/_5siHkFQPBQ>`_ at the top of this tutor
  1. The robot moves its arm to the pose goal to its front.
  2. The robot moves its arm to the joint goal at its side.
  3. The robot moves its arm back to a new pose goal while maintaining the end-effector level.
- 4. The robot moves its arm along the desired Cartesian path (a triangle up+forward, left, down+back).
+ 4. The robot moves its arm along the desired Cartesian path (a triangle down, right, up+left).
  5. A box object is added into the environment to the right of the arm.
     |B|
 

--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -247,16 +247,16 @@ int main(int argc, char** argv)
 
   geometry_msgs::Pose target_pose3 = start_pose2;
 
-  target_pose3.position.z += 0.2;
-  waypoints.push_back(target_pose3);  // up
-
-  target_pose3.position.y -= 0.1;
-  waypoints.push_back(target_pose3);  // left
-
   target_pose3.position.z -= 0.2;
+  waypoints.push_back(target_pose3);  // down
+
+  target_pose3.position.y -= 0.2;
+  waypoints.push_back(target_pose3);  // right
+
+  target_pose3.position.z += 0.2;
   target_pose3.position.y += 0.2;
   target_pose3.position.x -= 0.2;
-  waypoints.push_back(target_pose3);  // down and right
+  waypoints.push_back(target_pose3);  // up and left
 
   // Cartesian motions are frequently needed to be slower for actions such as approach and retreat
   // grasp motions. Here we demonstrate how to reduce the speed of the robot arm via a scaling factor


### PR DESCRIPTION
* updated move_group_interface tutorial's Cartesian path waypoints (example 4) so path is triangular
* updated description of the path