### PR TITLE
Add /rviz_visual_tools in RViz MarkerArray

### DIFF
--- a/doc/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/move_group_interface/move_group_interface_tutorial.rst
@@ -17,6 +17,9 @@ Running the Code
 Open two shells. In the first shell start RViz and wait for everything to finish loading: ::
 
   roslaunch panda_moveit_config demo.launch
+  
+**Note**: At this point after the RViz launches fill the **marker_topic** of **MarkerArray** Display as */rviz_visual_tools* by typing, in case it does not exist in the drop-down menu. Otherwise you would not get the expected output, i.e. visualizations such as trajectory line and texts are not shown on top of RViz screen and below launch file will output a ROS warning of:
+*Topic '/rviz_visual_tools' unable to connect to any subscribers within 0.5 sec. It is possible initially published visual messages will be lost.*.
 
 In the second shell, run the launch file: ::
 


### PR DESCRIPTION
When this is added, expected output is correctly observable in any machine. Otherwise, even though core functionality remains as is, visualizations such as colored trajectory line and informative texts on top of RViz screen stays hidden.