### PR TITLE
Remove long wait by adding grasp closure time

### DIFF
--- a/doc/pick_place/src/pick_place_tutorial.cpp
+++ b/doc/pick_place/src/pick_place_tutorial.cpp
@@ -54,6 +54,7 @@ void openGripper(trajectory_msgs::JointTrajectory& posture)
   posture.points[0].positions.resize(2);
   posture.points[0].positions[0] = 0.04;
   posture.points[0].positions[1] = 0.04;
+  posture.points[0].time_from_start = ros::Duration(0.5);
   // END_SUB_TUTORIAL
 }
 
@@ -70,6 +71,7 @@ void closedGripper(trajectory_msgs::JointTrajectory& posture)
   posture.points[0].positions.resize(2);
   posture.points[0].positions[0] = 0.00;
   posture.points[0].positions[1] = 0.00;
+  posture.points[0].time_from_start = ros::Duration(0.5);
   // END_SUB_TUTORIAL
 }
 


### PR DESCRIPTION
The [video in the Pick and Place tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/pick_place/pick_place_tutorial.html) is 45 seconds long. For 28 of those 45 seconds, the robot is standing still. This is because a default wait time of 7 seconds is added after every opening and closing of the gripper. This change fixes that time to 0.5 s and makes the movement look smooth.

I also proposed a small change to notify the user about this behavior in [this PR](https://github.com/ros-planning/moveit/pull/1004).