### PR TITLE
Don't show static robotic arm in collision

### DIFF
--- a/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -91,7 +91,7 @@ For the next steps we will want only the scene robot, start state and goal state
 
 #. Check the **Show Robot Visual** checkbox in the **Planned Path** tab
 
-#. Un-check the **Show Robot Visual** checkbox in the **Planned Path** tab
+#. Un-check the **Show Robot Visual** checkbox in the **Scene Robot** tab
 
 #. Check the **Query Goal State** checkbox in the **Planning Request** tab.
 


### PR DESCRIPTION
Tick correct box in rviz tutorial to remove static arm from visualization. At least in my case, i had to choose Scene Robot -> Show Robot Visual to remove the static robot arm (white) from visualization, so only goal state (red) and start state (green) are left.

In the picture directly below, you still see 3 arms, however, in the collision demonstration just below that the static arm is gone, so it must have been unchecked in  Scene Robot -> Show Robot.