### PR TITLE
remove memory leak from joint_model_group

### DIFF
--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -383,7 +383,9 @@ int main(int argc, char** argv)
   visual_tools.prompt("Press 'next' in the RvizVisualToolsGui window to once the collision object disapears");
 
   // END_TUTORIAL
-
+  delete joint_model_group;
+  joint_model_group = nullptr;
+  
   ros::shutdown();
   return 0;
 }


### PR DESCRIPTION
Delete raw pointer joint_model_group.

You could use smart pointers, of course, to prevent the mem leak.

Cheers

