### PR TITLE
Grammar and spelling fixes

### DIFF
--- a/doc/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/ompl_interface/ompl_interface_tutorial.rst
@@ -11,7 +11,7 @@ Here we review important configuration settings for OMPL. These settings can typ
 Longest Valid Segment Fraction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``longest_valid_segement_fraction`` defines the discretization of robot motions used for collision checking, and greatly affects the performance and reliability of OMPL-based solutions. A ``motion`` in this context can be thought of as an edge between two nodes in a graph, where nodes are waypoints along a trajectory. The default motion collision checker in OMPL simply discretizes the edge into a number of sub-states to collision check. Currently no continuous collision checking is available in OMPL/MoveIt!, though this is an area of current `discussion <https://github.com/ros-planning/moveit/issues/29>`_.
+The ``longest_valid_segment_fraction`` defines the discretization of robot motions used for collision checking and greatly affects the performance and reliability of OMPL-based solutions. A ``motion`` in this context can be thought of as an edge between two nodes in a graph, where nodes are waypoints along a trajectory. The default motion collision checker in OMPL simply discretizes the edge into a number of sub-states to collision check. No continuous collision checking is currently available in OMPL/MoveIt!, though this is an area of current `discussion <https://github.com/ros-planning/moveit/issues/29>`_.
 
 Specifically, ``longest_valid_segment_fraction`` is the fraction of the robot's state space that, given the robot isn't currently in collision, we assume the robot can travel while remaining collision free. For example, if ``longest_valid_segment_fraction = 0.01``, then we assume that if an edge between two nodes is less than 1/100th of the state space, then we don't need to explicity check any sub-states along that edge, just the two nodes it connects.
 
@@ -19,7 +19,7 @@ In addition to the ``longest_valid_segment_fraction`` parameter in the ``ompl_pl
 
 If both ``longest_valid_segment_fraction`` and ``maximum_waypoint_distance`` are set, then the variable that produces the most conservative discretization (the one that would generate the most states to collision check on a given edge) is chosen.
 
-Set ``longest_valid_segement_fraction`` (or ``maximum_waypoint_distance``) too low, and collision checking / motion planning will be very slow. Set too high and collisions will be missed around small or narrow objects. In addition, a high collision checking resolution will cause the path smoothers to output incomprehensible motions because they are able to "catch" the invalid path and then attempt to repair them by sampling around it, but imperfectly.
+Set ``longest_valid_segment_fraction`` (or ``maximum_waypoint_distance``) too low, and collision checking / motion planning will be very slow. Set too high and collisions will be missed around small or narrow objects. In addition, a high collision checking resolution will cause the path smoothers to output incomprehensible motions because they are able to "catch" the invalid path and then attempt to repair them by sampling around it, but imperfectly.
 
 A quick analysis of the effect of this parameter on two of the MoveIt! tutorial examples is documented `here <https://github.com/ros-planning/moveit/pull/337>`_.
 


### PR DESCRIPTION
Spelling: segement -> segment

Rephrased one sentence in the introduction.