### PR TITLE
Add Travis settings to deploy kinetic-devel build to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,21 @@ script:
   - rosdoc_lite -o build .
   # Run HTML tests on generated build output to check for 404 errors, etc
   - htmlproofer ./build --only-4xx --check-html --file-ignore ./build/html/genindex.html,./build/html/search.html,./build/html/index-msg.html --alt-ignore '/.*/' --url-ignore '#'
+
+# after_success and deploy are skipped if build is broken
+after_success:
+  # Tell GitHub Pages not to bypass Jekyll processing
+  - touch build/html/.nojekyll
+
+deploy:
+  # Deploy to gh-pages branch
+  provider: pages
+  # Don't delete built files
+  skip-cleanup: true
+  # Add to Environment Variables section of Travis CI repository settings page
+  github-token: $GITHUB_TOKEN
+  # Only copy build output directory to gh-pages
+  local_dir: build/html
+  on:
+    # Source branch
+    branch: kinetic-devel


### PR DESCRIPTION
* This CL will deploy the kinetic-devel build to gh-pages (only ~15min!): [https://ros-planning.github.io/moveit_tutorials/](https://ros-planning.github.io/moveit_tutorials/)

* Must first add GITHUB_TOKEN Travis environment variable to give permissions as described here: [https://docs.travis-ci.com/user/deployment/pages/](https://docs.travis-ci.com/user/deployment/pages/)

* [Here](https://nbbrooks.github.io/moveit_tutorials/) is an example gh-pages deployment of the tutorials on my personal fork where I've added the encrypted Travis environment variable

* This CL will be useful during WMD as tutorial updates will be visible in ~15 minutes instead of ~2 days with the current ROS build farm

* This does not affect the ROS build farm deployment