### PR TITLE
Update README to explain dual build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MoveIt! Tutorials
 
-This repository is automatically built by the ROS build farm and its output is hosted here: http://docs.ros.org/kinetic/api/moveit_tutorials/html/
+This repository is automatically built by two systems:
+* The Travis build output is immediately deployed to gh-pages here: https://ros-planning.github.io/moveit_tutorials/
+* The ROS build farm output is hosted here: http://docs.ros.org/kinetic/api/moveit_tutorials/html/
 
 The tutorials use the [reStructuredText](http://www.sphinx-doc.org/en/stable/rest.html) format commonly used in the Sphinx "Python Documentation Generator". This unfortunately differs from the common Markdown format.
 


### PR DESCRIPTION
The Travis build output is immediately deployed to gh-pages here: https://ros-planning.github.io/moveit_tutorials/
