### PR TITLE
Converted tf->tf2 for melodic & kinetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ find_package(catkin REQUIRED
     pcl_ros
     pcl_conversions
     rosbag
+    tf2_ros
+    tf2_eigen
+    tf2_geometry_msgs
 )
 
 find_package(Boost REQUIRED system filesystem date_time thread)

--- a/doc/interactivity/src/imarker.cpp
+++ b/doc/interactivity/src/imarker.cpp
@@ -38,7 +38,7 @@
 
 #include "interactivity/imarker.h"
 #include "interactivity/pose_string.h"
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 /* default callback which just prints the current pose */
 void IMarker::printFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback)
@@ -107,7 +107,7 @@ void IMarker::makeAxisControl()
 /* move to new pose */
 void IMarker::move(const Eigen::Affine3d& pose)
 {
-  tf::poseEigenToMsg(pose, imarker_.pose);
+  imarker_.pose = tf2::toMsg(pose);
   server_->applyChanges();
 }
 
@@ -120,8 +120,8 @@ void IMarker::initialize(interactive_markers::InteractiveMarkerServer& server, c
 {
   server_ = &server;
   imarker_.header.frame_id = frame_id;
-  tf::pointEigenToMsg(position, imarker_.pose.position);
-  tf::quaternionEigenToMsg(orientation, imarker_.pose.orientation);
+  imarker_.pose.position = tf2::toMsg(position);
+  imarker_.pose.orientation = tf2::toMsg(orientation);
   imarker_.scale = 0.3;
 
   imarker_.name = name;

--- a/doc/interactivity/src/interactive_robot.cpp
+++ b/doc/interactivity/src/interactive_robot.cpp
@@ -37,7 +37,7 @@
 // This code goes with the interactivity tutorial
 
 #include "interactivity/interactive_robot.h"
-#include <eigen_conversions/eigen_msg.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <moveit/robot_state/conversions.h>
 
 // default world object position is just in front and left of Panda robot.
@@ -123,7 +123,7 @@ void InteractiveRobot::movedRobotMarkerCallback(InteractiveRobot* robot,
                                                 const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback)
 {
   Eigen::Affine3d pose;
-  tf::poseMsgToEigen(feedback->pose, pose);
+  tf2::fromMsg(feedback->pose, pose);
   robot->setGroupPose(pose);
 }
 
@@ -132,7 +132,7 @@ void InteractiveRobot::movedWorldMarkerCallback(InteractiveRobot* robot,
                                                 const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback)
 {
   Eigen::Affine3d pose;
-  tf::poseMsgToEigen(feedback->pose, pose);
+  tf2::fromMsg(feedback->pose, pose);
   robot->setWorldObjectPose(pose);
 }
 
@@ -306,7 +306,7 @@ void InteractiveRobot::publishWorldState()
   marker.color.b = 0.0f;
   marker.color.a = 0.4f;
   marker.lifetime = ros::Duration();
-  tf::poseEigenToMsg(desired_world_object_pose_, marker.pose);
+  marker.pose = tf2::toMsg(desired_world_object_pose_);
   world_state_publisher_.publish(marker);
 }
 

--- a/doc/interactivity/src/pose_string.cpp
+++ b/doc/interactivity/src/pose_string.cpp
@@ -38,8 +38,8 @@
 
 #include "interactivity/pose_string.h"
 
-// tf
-#include <eigen_conversions/eigen_msg.h>
+// tf2
+#include <tf2_eigen/tf2_eigen.h>
 
 #include <iostream>
 #include <iomanip>
@@ -67,7 +67,5 @@ std::string PoseString(const geometry_msgs::Pose& pose)
  */
 std::string PoseString(const Eigen::Affine3d& pose)
 {
-  geometry_msgs::Pose msg;
-  tf::poseEigenToMsg(pose, msg);
-  return PoseString(msg);
+  return PoseString(tf2::toMsg(pose));
 }

--- a/doc/motion_planning_api/launch/motion_planning_api_tutorial.launch
+++ b/doc/motion_planning_api/launch/motion_planning_api_tutorial.launch
@@ -8,7 +8,7 @@
     <arg name="load_robot_description" value="true"/>
   </include>
 
-  <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="/use_gui" value="true"/>

--- a/doc/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch
+++ b/doc/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch
@@ -10,7 +10,7 @@
     <arg name="load_robot_description" value="true"/>
   </include>
 
-  <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="/use_gui" value="true"/>

--- a/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
+++ b/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
@@ -5,7 +5,7 @@
   <node pkg="moveit_tutorials" type="bag_publisher_maintain_time" name="point_clouds" />
 
   <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf" type="static_transform_publisher" name="to_temp_link" args="0 0.4 -0.6 0 0 0  temp_link panda_link0 10" />
-  <node pkg="tf" type="static_transform_publisher" name="to_panda_base" args="0 0 0 0 0.2 1.92 camera_rgb_optical_frame temp_link 10" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_temp_link" args="0 0.4 -0.6 0 0 0  temp_link panda_link0 10" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda_base" args="0 0 0 0 0.2 1.92 camera_rgb_optical_frame temp_link 10" />
 
 </launch>

--- a/doc/pick_place/src/pick_place_tutorial.cpp
+++ b/doc/pick_place/src/pick_place_tutorial.cpp
@@ -41,6 +41,9 @@
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
 #include <moveit/move_group_interface/move_group_interface.h>
 
+// TF2
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
 void openGripper(trajectory_msgs::JointTrajectory& posture)
 {
   // BEGIN_SUB_TUTORIAL open_gripper
@@ -91,7 +94,9 @@ void pick(moveit::planning_interface::MoveGroupInterface& move_group)
   // Therefore, the position for panda_link8 = 5 - (length of cube/2 - distance b/w panda_link8 and palm of eef - some
   // extra padding)
   grasps[0].grasp_pose.header.frame_id = "panda_link0";
-  grasps[0].grasp_pose.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(-M_PI / 2, -M_PI / 4, -M_PI / 2);
+  tf2::Quaternion orientation;
+  orientation.setRPY(-M_PI / 2, -M_PI / 4, -M_PI / 2);
+  grasps[0].grasp_pose.pose.orientation = tf2::toMsg(orientation);
   grasps[0].grasp_pose.pose.position.x = 0.415;
   grasps[0].grasp_pose.pose.position.y = 0;
   grasps[0].grasp_pose.pose.position.z = 0.5;
@@ -146,7 +151,9 @@ void place(moveit::planning_interface::MoveGroupInterface& group)
   // Setting place location pose
   // +++++++++++++++++++++++++++
   place_location[0].place_pose.header.frame_id = "panda_link0";
-  place_location[0].place_pose.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(0, 0, M_PI / 2);
+  tf2::Quaternion orientation;
+  orientation.setRPY(0, 0, M_PI / 2);
+  place_location[0].place_pose.pose.orientation = tf2::toMsg(orientation);
 
   /* While placing it is the exact location of the center of the object. */
   place_location[0].place_pose.pose.position.x = 0;

--- a/doc/planning_scene/src/planning_scene_tutorial.cpp
+++ b/doc/planning_scene/src/planning_scene_tutorial.cpp
@@ -41,7 +41,6 @@
 #include <moveit/planning_scene/planning_scene.h>
 
 #include <moveit/kinematic_constraints/utils.h>
-#include <eigen_conversions/eigen_msg.h>
 
 // BEGIN_SUB_TUTORIAL stateFeasibilityTestExample
 //

--- a/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
+++ b/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
@@ -12,8 +12,8 @@
     <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
   </node>
 
-  <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 1 /world/panda_link0 /panda_link0 10" />
+  <!-- If needed, broadcast static tf2 for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 1 /world/panda_link0 /panda_link0 10" />
 
   <!-- launch interactivity_tutorial -->
   <node name="visualizing_collisions_tutorial" pkg="moveit_tutorials" type="visualizing_collisions_tutorial" respawn="false" output="screen">

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,9 @@
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>rosbag</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <run_depend>panda_moveit_config</run_depend>
   <run_depend>pluginlib</run_depend>
@@ -39,5 +42,8 @@
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>
   <run_depend>rosbag</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
This commit resolves https://github.com/ros-planning/moveit_tutorials/issues/227 . It's intended to fix the tutorials for `melodic`, but these changes should be backward compatible with `kinetic`, in that this should build and run there as well. It was only a handful of conversion functions that needed to be updated. I tested on an `18.04 melodic` machine, but I would recommend double checking against a `16.04 kinetic` machine.

A screencap of the successful tutorial for good measure:

![tf2_pick_n_place](https://user-images.githubusercontent.com/850874/46925644-ea088280-cffa-11e8-8361-a13e381b9993.png)
