### PR TITLE
Update move_group_python_interface_tutorial

### DIFF
--- a/doc/move_group_python_interface/move_group_python_interface_tutorial.rst
+++ b/doc/move_group_python_interface/move_group_python_interface_tutorial.rst
@@ -17,7 +17,7 @@ If you haven't already done so, make sure you've completed the steps in `Getting
 
 Start RViz and MoveGroup node
 -----------------------------
-Open two shells. Start RViz and wait for everything to finish loading in the first shell: ::
+Open two shells. Run this command in the first shell and wait for everything to finish loading: ::
 
   roslaunch panda_moveit_config demo.launch
 


### PR DESCRIPTION
Changed the instructions to be more clear to use the roslaunch command to open RViz in the first shell. Starting rivz separately does not launch roscore and this is already taken care of by the roslaunch command.