### PR TITLE
Cleaning python move_group_interface tutorials

### DIFF
--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -54,6 +54,7 @@ from std_msgs.msg import String
 from moveit_commander.conversions import pose_to_list
 ## END_SUB_TUTORIAL
 
+
 def all_close(goal, actual, tolerance):
   """
   Convenience method for testing if a list of values are within a tolerance of their counterparts in another list
@@ -76,6 +77,7 @@ def all_close(goal, actual, tolerance):
 
   return True
 
+
 class MoveGroupPythonIntefaceTutorial(object):
   """MoveGroupPythonIntefaceTutorial"""
   def __init__(self):
@@ -85,27 +87,28 @@ class MoveGroupPythonIntefaceTutorial(object):
     ##
     ## First initialize `moveit_commander`_ and a `rospy`_ node:
     moveit_commander.roscpp_initialize(sys.argv)
-    rospy.init_node('move_group_python_interface_tutorial',
-                    anonymous=True)
+    rospy.init_node('move_group_python_interface_tutorial', anonymous=True)
 
-    ## Instantiate a `RobotCommander`_ object. This object is the outer-level interface to
-    ## the robot:
+    ## Instantiate a `RobotCommander`_ object. Provides information such as the robot's
+    ## kinematic model and the robot's current joint states
     robot = moveit_commander.RobotCommander()
 
-    ## Instantiate a `PlanningSceneInterface`_ object.  This object is an interface
-    ## to the world surrounding the robot:
+    ## Instantiate a `PlanningSceneInterface`_ object.  This provides a remote interface
+    ## for getting, setting, and updating the robot's internal understanding of the
+    ## surrounding world:
     scene = moveit_commander.PlanningSceneInterface()
 
     ## Instantiate a `MoveGroupCommander`_ object.  This object is an interface
-    ## to one group of joints.  In this case the group is the joints in the Panda
-    ## arm so we set ``group_name = panda_arm``. If you are using a different robot,
-    ## you should change this value to the name of your robot arm planning group.
-    ## This interface can be used to plan and execute motions on the Panda:
+    ## to a planning group (group of joints).  In this tutorial the group is the primary
+    ## arm joints in the Panda robot, so we set the group's name to "panda_arm".
+    ## If you are using a different robot, change this value to the name of your robot
+    ## arm planning group.
+    ## This interface can be used to plan and execute motions:
     group_name = "panda_arm"
-    group = moveit_commander.MoveGroupCommander(group_name)
+    move_group = moveit_commander.MoveGroupCommander(group_name)
 
-    ## We create a `DisplayTrajectory`_ publisher which is used later to publish
-    ## trajectories for RViz to visualize:
+    ## Create a `DisplayTrajectory`_ ROS publisher which is used to display
+    ## trajectories in Rviz:
     display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path',
                                                    moveit_msgs.msg.DisplayTrajectory,
                                                    queue_size=20)
@@ -117,16 +120,16 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## Getting Basic Information
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^
     # We can get the name of the reference frame for this robot:
-    planning_frame = group.get_planning_frame()
-    print "============ Reference frame: %s" % planning_frame
+    planning_frame = move_group.get_planning_frame()
+    print "============ Planning frame: %s" % planning_frame
 
     # We can also print the name of the end-effector link for this group:
-    eef_link = group.get_end_effector_link()
-    print "============ End effector: %s" % eef_link
+    eef_link = move_group.get_end_effector_link()
+    print "============ End effector link: %s" % eef_link
 
     # We can get a list of all the groups in the robot:
     group_names = robot.get_group_names()
-    print "============ Robot Groups:", robot.get_group_names()
+    print "============ Available Planning Groups:", robot.get_group_names()
 
     # Sometimes for debugging it is useful to print the entire state of the
     # robot:
@@ -139,17 +142,18 @@ class MoveGroupPythonIntefaceTutorial(object):
     self.box_name = ''
     self.robot = robot
     self.scene = scene
-    self.group = group
+    self.move_group = move_group
     self.display_trajectory_publisher = display_trajectory_publisher
     self.planning_frame = planning_frame
     self.eef_link = eef_link
     self.group_names = group_names
 
+
   def go_to_joint_state(self):
     # Copy class variables to local variables to make the web tutorials more clear.
     # In practice, you should use the class variables directly unless you have a good
     # reason not to.
-    group = self.group
+    move_group = self.move_group
 
     ## BEGIN_SUB_TUTORIAL plan_to_joint_state
     ##
@@ -158,7 +162,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## The Panda's zero configuration is at a `singularity <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>`_ so the first
     ## thing we want to do is move it to a slightly better configuration.
     # We can get the joint values from the group and adjust some of the values:
-    joint_goal = group.get_current_joint_values()
+    joint_goal = move_group.get_current_joint_values()
     joint_goal[0] = 0
     joint_goal[1] = -pi/4
     joint_goal[2] = 0
@@ -169,24 +173,23 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     # The go command can be called with joint values, poses, or without any
     # parameters if you have already set the pose or joint target for the group
-    group.go(joint_goal, wait=True)
+    move_group.go(joint_goal, wait=True)
 
     # Calling ``stop()`` ensures that there is no residual movement
-    group.stop()
+    move_group.stop()
 
     ## END_SUB_TUTORIAL
 
     # For testing:
-    # Note that since this section of code will not be included in the tutorials
-    # we use the class variable rather than the copied state variable
-    current_joints = self.group.get_current_joint_values()
+    current_joints = move_group.get_current_joint_values()
     return all_close(joint_goal, current_joints, 0.01)
+
 
   def go_to_pose_goal(self):
     # Copy class variables to local variables to make the web tutorials more clear.
     # In practice, you should use the class variables directly unless you have a good
     # reason not to.
-    group = self.group
+    move_group = self.move_group
 
     ## BEGIN_SUB_TUTORIAL plan_to_pose
     ##
@@ -199,22 +202,23 @@ class MoveGroupPythonIntefaceTutorial(object):
     pose_goal.position.x = 0.4
     pose_goal.position.y = 0.1
     pose_goal.position.z = 0.4
-    group.set_pose_target(pose_goal)
+
+    move_group.set_pose_target(pose_goal)
 
     ## Now, we call the planner to compute the plan and execute it.
-    plan = group.go(wait=True)
+    plan = move_group.go(wait=True)
     # Calling `stop()` ensures that there is no residual movement
-    group.stop()
+    move_group.stop()
     # It is always good to clear your targets after planning with poses.
     # Note: there is no equivalent function for clear_joint_value_targets()
-    group.clear_pose_targets()
+    move_group.clear_pose_targets()
 
     ## END_SUB_TUTORIAL
 
     # For testing:
     # Note that since this section of code will not be included in the tutorials
     # we use the class variable rather than the copied state variable
-    current_pose = self.group.get_current_pose().pose
+    current_pose = self.move_group.get_current_pose().pose
     return all_close(pose_goal, current_pose, 0.01)
 
 
@@ -222,7 +226,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     # Copy class variables to local variables to make the web tutorials more clear.
     # In practice, you should use the class variables directly unless you have a good
     # reason not to.
-    group = self.group
+    move_group = self.move_group
 
     ## BEGIN_SUB_TUTORIAL plan_cartesian_path
     ##
@@ -234,7 +238,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     ##
     waypoints = []
 
-    wpose = group.get_current_pose().pose
+    wpose = move_group.get_current_pose().pose
     wpose.position.z -= scale * 0.1  # First move up (z)
     wpose.position.y += scale * 0.2  # and sideways (y)
     waypoints.append(copy.deepcopy(wpose))
@@ -250,7 +254,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     # translation.  We will disable the jump threshold by setting it to 0.0,
     # ignoring the check for infeasible jumps in joint space, which is sufficient
     # for this tutorial.
-    (plan, fraction) = group.compute_cartesian_path(
+    (plan, fraction) = move_group.compute_cartesian_path(
                                        waypoints,   # waypoints to follow
                                        0.01,        # eef_step
                                        0.0)         # jump_threshold
@@ -259,6 +263,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     return plan, fraction
 
     ## END_SUB_TUTORIAL
+
 
   def display_trajectory(self, plan):
     # Copy class variables to local variables to make the web tutorials more clear.
@@ -286,11 +291,12 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     ## END_SUB_TUTORIAL
 
+
   def execute_plan(self, plan):
     # Copy class variables to local variables to make the web tutorials more clear.
     # In practice, you should use the class variables directly unless you have a good
     # reason not to.
-    group = self.group
+    move_group = self.move_group
 
     ## BEGIN_SUB_TUTORIAL execute_plan
     ##
@@ -298,11 +304,12 @@ class MoveGroupPythonIntefaceTutorial(object):
     ## ^^^^^^^^^^^^^^^^
     ## Use execute if you would like the robot to follow
     ## the plan that has already been computed:
-    group.execute(plan, wait=True)
+    move_group.execute(plan, wait=True)
 
     ## **Note:** The robot's current joint state must be within some tolerance of the
     ## first waypoint in the `RobotTrajectory`_ or ``execute()`` will fail
     ## END_SUB_TUTORIAL
+
 
   def wait_for_state_update(self, box_is_known=False, box_is_attached=False, timeout=4):
     # Copy class variables to local variables to make the web tutorials more clear.
@@ -344,6 +351,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     # If we exited the while loop without returning then we timed out
     return False
     ## END_SUB_TUTORIAL
+
 
   def add_box(self, timeout=4):
     # Copy class variables to local variables to make the web tutorials more clear.
@@ -398,6 +406,7 @@ class MoveGroupPythonIntefaceTutorial(object):
     # We wait for the planning scene to update.
     return self.wait_for_state_update(box_is_attached=True, box_is_known=False, timeout=timeout)
 
+
   def detach_box(self, timeout=4):
     # Copy class variables to local variables to make the web tutorials more clear.
     # In practice, you should use the class variables directly unless you have a good
@@ -416,6 +425,7 @@ class MoveGroupPythonIntefaceTutorial(object):
 
     # We wait for the planning scene to update.
     return self.wait_for_state_update(box_is_known=True, box_is_attached=False, timeout=timeout)
+
 
   def remove_box(self, timeout=4):
     # Copy class variables to local variables to make the web tutorials more clear.
@@ -440,7 +450,13 @@ class MoveGroupPythonIntefaceTutorial(object):
 
 def main():
   try:
-    print "============ Press `Enter` to begin the tutorial by setting up the moveit_commander (press ctrl-d to exit) ..."
+    print ""
+    print "----------------------------------------------------------"
+    print "Welcome to the MoveIt! MoveGroup Python Interface Tutorial"
+    print "----------------------------------------------------------"
+    print "Press Ctrl-D to exit at any time"
+    print ""
+    print "============ Press `Enter` to begin the tutorial by setting up the moveit_commander ..."
     raw_input()
     tutorial = MoveGroupPythonIntefaceTutorial()
 


### PR DESCRIPTION
- Improve explanations of code
- Improving wording
- Rename 'group' to 'move_group'
- Fix spacing