### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -37,11 +37,11 @@ Download the Example Code
 Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download these tutorials: ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit_tutorials.git
+  git clone -b kinetic-devel https://github.com/ros-planning/moveit_tutorials.git
 
 You will also need a ``panda_moveit_config`` package to follow along with these tutorials: ::
 
-  git clone https://github.com/ros-planning/panda_moveit_config.git
+  git clone -b kinetic-devel https://github.com/ros-planning/panda_moveit_config.git
 
 .. note:: For now we will use a pre-generated ``panda_moveit_config`` package but later we will learn how to make our own in the `MoveIt! Setup Assistant tutorial <../setup_assistant/setup_assistant_tutorial.html>`_.
 


### PR DESCRIPTION
Catkin build fails on default branch when another is needed. Added branch kinetic-devel to the git checkout command.

see [https://answers.ros.org/question/307792/catkin-build-error-for-moveit-workspace-setup/](url)