### PR TITLE
Update planning pipeline adapters

### DIFF
--- a/doc/stomp_planner/stomp_planner_tutorial.rst
+++ b/doc/stomp_planner/stomp_planner_tutorial.rst
@@ -42,10 +42,11 @@ Using STOMP with Your Robot
       <arg name="planning_plugin" value="stomp_moveit/StompPlannerManager" />
 
       <!-- The request adapters (plugins) ORDER MATTERS -->
-      <arg name="planning_adapters" value="default_planner_request_adapters/FixWorkspaceBounds
-                                          default_planner_request_adapters/FixStartStateBounds
-                                          default_planner_request_adapters/FixStartStateCollision
-                                          default_planner_request_adapters/FixStartStatePathConstraints" />
+      <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+                                           default_planner_request_adapters/FixWorkspaceBounds
+                                           default_planner_request_adapters/FixStartStateBounds
+                                           default_planner_request_adapters/FixStartStateCollision
+                                           default_planner_request_adapters/FixStartStatePathConstraints" />
       <arg name="start_state_max_bounds_error" value="0.1" />
       <param name="planning_plugin" value="$(arg planning_plugin)" />
       <param name="request_adapters" value="$(arg planning_adapters)" />


### PR DESCRIPTION
This PR adds the `AddTimeParameterization` planning adapter to the documentation of the `stomp_planning_pipeline.launch.xml` file.

If any of the start state modification adapters change the start state of the trajectory, the original start state will be prepended to the trajectory without velocity or acceleration information. Without the time parameterization adapter, subsequent output trajectory adapters (such as the `industrial_trajectory_filters/UniformSampleFilter` in my case) or robot drivers might fail.

This adapter is included by default in the OMPL planning pipeline launch file, so the STOMP documentation should probably also include it by default since we are providing this as a template for others to copy in their implementation of STOMP in MoveIt.