### PR TITLE
Add a Jacobian arm-jogging tutorial

### DIFF
--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -34,11 +34,11 @@ Launch the Gazebo simulation:
 
 ``roslaunch motoman_moveit sia5_gazebo_nishida_lab_moveit_planning_execution.launch``
 
-Move the arm to a non-singular configuration then launch the jogger:
+Move the arm to a non-singular (non zero joint values) configuration then launch the jogger:
 
 ``roslaunch moveit_experimental jog_arm_server.launch``
 
-You can publish jogging commands with:
+You can publish example jogging commands with:
 
 .. code-block:: bash
 
@@ -57,7 +57,7 @@ Settings
 --------
 User-configurable settings of the jog node are well-documented in ``config/sia5_simulated_config.yaml``.
 
-Configuring Control Devices (Gamepads, joysticks, etc)
+Configuring Control Devices (Gamepads, Joysticks, etc)
 ------------------------------------------------------
 The ``jog_arm/config`` folder contains two examples of converting SpaceNavigator 3D mouse commands to jog commands. ``spacenav_teleop_tools.launch`` loads a config file then publishes commands to the jogger on the ``spacenav/joy topic``. It is easy to create your own config file for a particular joystick or gamepad. We welcome pull requests of config files for new controllers.
 

--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -5,10 +5,16 @@ This tutorial shows how to send real-time jogging commands to a ROS-enabled robo
 
 .. raw:: html
 
-        <object width="480" height="385"><param name="movie"
-        value="http://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"></param><param
-        name="allowFullScreen" value="true"></param><param
-        name="allowscriptaccess" value="always"></param></object>
+        <object width="480" height="385">
+
+        <param name="movie"
+        value="http://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"></param>
+
+        <param name="allowFullScreen" value="true"></param>
+
+        <param name="allowscriptaccess" value="always"></param>
+
+        </object>
 
 Robot Requirements
 ------------------

--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -24,30 +24,36 @@ If you haven't already done so, make sure you've completed the steps in `Getting
 
 You can test the jogger with this `Gazebo simulator <https://github.com/UTNuclearRoboticsPublic/motoman_project>`_. Gazebo is necessary because it provides ros\_control controllers. Clone the repo into your catkin workspace. Install dependencies:
 
+.. code-block:: bash
+
     sudo apt install ros-kinetic-control* ros-kinetic-gazebo-ros-control* ros-kinetic-joint-state-controller ros-kinetic-position-controllers ros-kinetic-joint-trajectory-controller
 
-Then build the workspace with ``catkin_make``.
+Then build the workspace with ``catkin build``.
 
 Launch the Gazebo simulation:
 
-``roslaunch motoman_gazebo sia5_gazebo_nishida_lab.launch``
+.. code-block:: bash
 
-``roslaunch motoman_moveit sia5_gazebo_nishida_lab_moveit_planning_execution.launch``
+  roslaunch motoman_gazebo sia5_gazebo_nishida_lab.launch
+
+  roslaunch motoman_moveit sia5_gazebo_nishida_lab_moveit_planning_execution.launch
 
 Move the arm to a non-singular (non zero joint values) configuration then launch the jogger:
 
-``roslaunch moveit_experimental jog_arm_server.launch``
+.. code-block:: bash
+
+  roslaunch moveit_experimental jog_arm_server.launch
 
 You can publish example jogging commands with:
 
 .. code-block:: bash
 
 	rostopic pub -r 100 /jog_arm_server/delta_jog_cmds geometry_msgs/TwistStamped "header: auto
-	twist:                 
-	  linear:              
-	    x: 0.0             
-	    y: -1.0            
-	    z: 1.0            
+	twist:
+	  linear:
+	    x: 0.0
+	    y: -1.0
+	    z: 1.0
 	  angular:
 	    x: 0.0
 	    y: 0.0
@@ -59,6 +65,6 @@ User-configurable settings of the jog node are well-documented in ``config/sia5_
 
 Configuring Control Devices (Gamepads, Joysticks, etc)
 ------------------------------------------------------
-The ``jog_arm/config`` folder contains two examples of converting SpaceNavigator 3D mouse commands to jog commands. ``spacenav_teleop_tools.launch`` loads a config file then publishes commands to the jogger on the ``spacenav/joy topic``. It is easy to create your own config file for a particular joystick or gamepad. We welcome pull requests of config files for new controllers.
+The ``jog_arm/config`` folder contains two examples of converting `SpaceNavigator <https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords=spacenavigator>`_ 3D mouse commands to jog commands. ``spacenav_teleop_tools.launch`` loads a config file then publishes commands to the jogger on the ``spacenav/joy topic``. It is easy to create your own config file for a particular joystick or gamepad. We welcome pull requests of config files for new controllers.
 
 ``spacenav_cpp.launch`` launches a C++ node that does the same thing but with less latency. We do not plan to accept C++ pull requests for more controller types because there is a lot of overhead involved in supporting them.

--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -1,5 +1,5 @@
 Real-Time Arm Jogging
-==========================================
+=====================
 
 This tutorial shows how to send real-time jogging commands to a ROS robot. Some nice features of the jogger are singularity handling and collision checking.
 

--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -1,0 +1,64 @@
+Real-Time Arm Jogging
+==========================================
+
+This tutorial shows how to send real-time jogging commands to a ROS robot. Some nice features of the jogger are singularity handling and collision checking.
+
+.. raw:: html
+
+        <object width="480" height="385"><param name="movie"
+        value="http://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"></param><param
+        name="allowFullScreen" value="true"></param><param
+        name="allowscriptaccess" value="always"></param></object>
+
+Robot Requirements
+------------------
+The jogger streams an array of position or velocity commands to the robot controller. This is compatible with ros\_control ``position_controllers/JointGroupPositionControllers`` or ``velocity_controllers/JointGroupVelocityControllers``. Check if these controllers are available for your robot by searching for the controller config file (typically named ``controllers.yaml``).
+
+Jogging may work on other robots that have a different control scheme but there is no guarantee. It has been tested heavily on UR robots using ``ur_modern_driver``. The jogger currently does not limit joint jerk so it is not compatible with most heavy industrial robots.
+
+The jogger can publish ``trajectory_msgs/JointTrajectory`` or ``std_msgs/Float64MultiArray`` message types. This is configured in a yaml file (see ``config/sia5_simulated_config.yaml`` for an example).
+
+Getting Started
+---------------
+If you haven't already done so, make sure you've completed the steps in `Getting Started <../getting_started/getting_started.html>`_.
+
+You can test the jogger with this `Gazebo simulator <https://github.com/UTNuclearRoboticsPublic/motoman_project>`_. Gazebo is necessary because it provides ros\_control controllers. Clone the repo into your catkin workspace. Install dependencies:
+
+``sudo apt install ros-kinetic-contro* ros-kinetic-gazebo-ros-contro* ros-kinetic-joint-state-controller ros-kinetic-position-controllers ros-kinetic-joint-trajectory-controller``
+
+Then build the workspace with ``catkin_make``.
+
+Launch the Gazebo simulation:
+
+``roslaunch motoman_gazebo sia5_gazebo_nishida_lab.launch``
+
+``roslaunch motoman_moveit sia5_gazebo_nishida_lab_moveit_planning_execution.launch``
+
+Move the arm to a non-singular configuration then launch the jogger:
+
+``roslaunch moveit_experimental jog_arm_server.launch``
+
+You can publish jogging commands with:
+
+.. code-block:: bash
+
+	rostopic pub -r 100 /jog_arm_server/delta_jog_cmds geometry_msgs/TwistStamped "header: auto
+	twist:                 
+	  linear:              
+	    x: 0.0             
+	    y: -1.0            
+	    z: 1.0            
+	  angular:
+	    x: 0.0
+	    y: 0.0
+	    z: 0.0"
+
+Settings
+--------
+User-configurable settings of the jog node are well-documented in ``config/sia5_simulated_config.yaml``.
+
+Configuring Control Devices (Gamepads, joysticks, etc)
+------------------------------------------------------
+The ``jog_arm/config`` folder contains two examples of converting SpaceNavigator 3D mouse commands to jog commands. ``spacenav_teleop_tools.launch`` loads a config file then publishes commands to the jogger on the ``spacenav/joy topic``. It is easy to create your own config file for a particular joystick or gamepad. We welcome pull requests of config files for new controllers.
+
+``spacenav_cpp.launch`` launches a C++ node that does the same thing but with less latency. We do not plan to accept C++ pull requests for more controller types because there is a lot of overhead involved in supporting them.

--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -5,16 +5,14 @@ This tutorial shows how to send real-time jogging commands to a ROS-enabled robo
 
 .. raw:: html
 
-        <object width="480" height="385">
-
-        <param name="movie"
-        value="http://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"></param>
-
-        <param name="allowFullScreen" value="true"></param>
-
-        <param name="allowscriptaccess" value="always"></param>
-
-        </object>
+        <object width="480" height="385"><param name="movie"
+        value="http://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"></param><param
+        name="allowFullScreen" value="true"></param><param
+        name="allowscriptaccess" value="always"></param><embed
+        src="http://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"
+        type="application/x-shockwave-flash" allowscriptaccess="always"
+        allowfullscreen="true" width="480"
+        height="385"></embed></object>
 
 Robot Requirements
 ------------------

--- a/doc/arm_jogging/arm_jogging_tutorial.rst
+++ b/doc/arm_jogging/arm_jogging_tutorial.rst
@@ -1,7 +1,7 @@
 Real-Time Arm Jogging
 =====================
 
-This tutorial shows how to send real-time jogging commands to a ROS robot. Some nice features of the jogger are singularity handling and collision checking.
+This tutorial shows how to send real-time jogging commands to a ROS-enabled robot. Some nice features of the jogger are singularity handling and collision checking that prevents operator from breaking the robot.
 
 .. raw:: html
 
@@ -12,9 +12,9 @@ This tutorial shows how to send real-time jogging commands to a ROS robot. Some 
 
 Robot Requirements
 ------------------
-The jogger streams an array of position or velocity commands to the robot controller. This is compatible with ros\_control ``position_controllers/JointGroupPositionControllers`` or ``velocity_controllers/JointGroupVelocityControllers``. Check if these controllers are available for your robot by searching for the controller config file (typically named ``controllers.yaml``).
+The jogger streams an array of position or velocity commands to the robot controller. This is compatible with ros\_control ``position_controllers/JointGroupPositionControllers`` or ``velocity_controllers/JointGroupVelocityControllers``. You can check if these controllers are available for your robot by searching for the controller config file (typically named ``controllers.yaml``).
 
-Jogging may work on other robots that have a different control scheme but there is no guarantee. It has been tested heavily on UR robots using ``ur_modern_driver``. The jogger currently does not limit joint jerk so it is not compatible with most heavy industrial robots.
+Jogging may work on other robots that have a different control scheme but there is no guarantee. It has been tested heavily on UR robots using the [ur_modern_driver](https://github.com/ros-industrial/ur_modern_driver). The jogger currently does not limit joint jerk so may not be compatible with most heavy industrial robots.
 
 The jogger can publish ``trajectory_msgs/JointTrajectory`` or ``std_msgs/Float64MultiArray`` message types. This is configured in a yaml file (see ``config/sia5_simulated_config.yaml`` for an example).
 
@@ -24,7 +24,7 @@ If you haven't already done so, make sure you've completed the steps in `Getting
 
 You can test the jogger with this `Gazebo simulator <https://github.com/UTNuclearRoboticsPublic/motoman_project>`_. Gazebo is necessary because it provides ros\_control controllers. Clone the repo into your catkin workspace. Install dependencies:
 
-``sudo apt install ros-kinetic-contro* ros-kinetic-gazebo-ros-contro* ros-kinetic-joint-state-controller ros-kinetic-position-controllers ros-kinetic-joint-trajectory-controller``
+    sudo apt install ros-kinetic-control* ros-kinetic-gazebo-ros-control* ros-kinetic-joint-state-controller ros-kinetic-position-controllers ros-kinetic-joint-trajectory-controller
 
 Then build the workspace with ``catkin_make``.
 

--- a/doc/joystick_control_teleoperation/joystick_control_teleoperation_tutorial.rst
+++ b/doc/joystick_control_teleoperation/joystick_control_teleoperation_tutorial.rst
@@ -12,6 +12,8 @@ If you haven't already done so, make sure you've completed the steps in `Getting
 
 Running the Code
 ----------------
+This jogging should only be used for simulated robots because some IK solvers can cause a joint jump. To jog a real robot, use the Jacobian-based `Real-Time Arm Jogging <../arm_jogging/arm_jogging_tutorial.html>`_ instead.
+
 Open two shells and make sure you have re-sourced the setup files in both of them: ::
 
   source ~/ws_moveit/devel/setup.bash

--- a/doc/joystick_control_teleoperation/joystick_control_teleoperation_tutorial.rst
+++ b/doc/joystick_control_teleoperation/joystick_control_teleoperation_tutorial.rst
@@ -12,8 +12,6 @@ If you haven't already done so, make sure you've completed the steps in `Getting
 
 Running the Code
 ----------------
-This jogging should only be used for simulated robots because some IK solvers can cause a joint jump. To jog a real robot, use the Jacobian-based `Real-Time Arm Jogging <../arm_jogging/arm_jogging_tutorial.html>`_ instead.
-
 Open two shells and make sure you have re-sourced the setup files in both of them: ::
 
   source ~/ws_moveit/devel/setup.bash

--- a/index.rst
+++ b/index.rst
@@ -78,6 +78,7 @@ Miscellaneous
    :maxdepth: 1
 
    doc/joystick_control_teleoperation/joystick_control_teleoperation_tutorial
+   doc/arm_jogging/arm_jogging_tutorial
    doc/benchmarking/benchmarking_tutorial
    doc/tests/tests_tutorial
 


### PR DESCRIPTION
This is a tutorial for the MoveIt! jogging PR (https://github.com/ros-planning/moveit/pull/1244).

I've forked Prof. Nishida's Motoman repository to make a Gazebo example. I hope that's OK, @Yuji-Ninomiya @AtsukiYokota @NishidaTakeshiLab? If not, I can probably find a different example.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
