### PR TITLE
fixing the motion planning pipeline tutorial

### DIFF
--- a/doc/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch
+++ b/doc/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch
@@ -6,28 +6,9 @@
   <arg name="planning_plugin" value="ompl_interface/OMPLPlanner" />
   <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints" />
 
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="true"/>
-  </include>
-
-  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
-
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="true"/>
-  </node>
-
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
-
-  <include file="$(find panda_moveit_config)/launch/moveit_rviz.launch">
-  </include>
-
   <node name="motion_planning_pipeline_tutorial" pkg="moveit_tutorials" type="motion_planning_pipeline_tutorial" respawn="false" launch-prefix="$(arg launch_prefix)" output="screen">
     <param name="planning_plugin" value="$(arg planning_plugin)" />
     <param name="request_adapters" value="$(arg planning_adapters)" />
     <param name="start_state_max_bounds_error" value="0.1" />
   </node>
-
-  <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
-  <rosparam command="load" file="$(find panda_moveit_config)/config/ompl_planning.yaml"/>
-
 </launch>

--- a/doc/motion_planning_pipeline/motion_planning_pipeline_tutorial.rst
+++ b/doc/motion_planning_pipeline/motion_planning_pipeline_tutorial.rst
@@ -15,7 +15,11 @@ If you haven't already done so, make sure you've completed the steps in `Getting
 
 Running the Code
 ----------------
-Roslaunch the launch file to run the code directly from moveit_tutorials: ::
+Open two shells. In the first shell start RViz and wait for everything to finish loading: ::
+
+  roslaunch panda_moveit_config demo.launch
+
+In the second shell, run the launch file: ::
 
  roslaunch moveit_tutorials motion_planning_pipeline_tutorial.launch
 

--- a/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -73,7 +73,6 @@ int main(int argc, char** argv)
   // will create a planning scene, monitors planning scene diffs, and apply the diffs to it's
   // internal planning scene. We then call startSceneMonitor, startWorldGeometryMonitor and
   // startStateMonitor to fully initialize the planning scene monitor
-  //
   planning_scene_monitor::PlanningSceneMonitorPtr psm(
       new planning_scene_monitor::PlanningSceneMonitor(robot_model_loader));
 

--- a/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -79,10 +79,10 @@ int main(int argc, char** argv)
   /* listen for planning scene messages on topic /XXX and apply them to the internal planning scene
                        the internal planning scene accordingly */
   psm->startSceneMonitor();
-  // listens to changes of world geometry, collision objects, and (optionally) octomaps
+  /* listens to changes of world geometry, collision objects, and (optionally) octomaps
                                 world geometry, collision objects and optionally octomaps */
   psm->startWorldGeometryMonitor();
-  // listen to joint state updates as well as changes in attached collision objects
+  /* listen to joint state updates as well as changes in attached collision objects
                         and update the internal planning scene accordingly*/
   psm->startStateMonitor();
 
@@ -240,7 +240,6 @@ int main(int argc, char** argv)
   // should happen either before planning takes place or after the planning
   // has been done on the resultant path
 
-  /* First, set the state in the planning scene to the final state of the last plan */
   /* First, set the state in the planning scene to the final state of the last plan */
   robot_state = planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentStateUpdated(response.trajectory_start);
   robot_state->setJointGroupPositions(joint_model_group, response.trajectory.joint_trajectory.points.back().positions);

--- a/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -77,13 +77,13 @@ int main(int argc, char** argv)
   planning_scene_monitor::PlanningSceneMonitorPtr psm(
       new planning_scene_monitor::PlanningSceneMonitor(robot_model_loader));
 
-  /* statSceneMonitor: This method starts a subscriber which listens for planning scene messages and updates
+  /* listen for planning scene messages on topic /XXX and apply them to the internal planning scene
                        the internal planning scene accordingly */
   psm->startSceneMonitor();
-  /* startWorldGeometryMonitor: This method starts the world geometry update monitor which listens for changes to
+  // listens to changes of world geometry, collision objects, and (optionally) octomaps
                                 world geometry, collision objects and optionally octomaps */
   psm->startWorldGeometryMonitor();
-  /* startStateMonitor: Starts subscribers that listen for changes in joint state, and attached collision objects topics
+  // listen to joint state updates as well as changes in attached collision objects
                         and update the internal planning scene accordingly*/
   psm->startStateMonitor();
 

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <build_depend>interactive_markers</build_depend>
   <build_depend>geometric_shapes</build_depend>
   <build_depend>moveit_visual_tools</build_depend>
+  <build_depend>rviz_visual_tools</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>rosbag</build_depend>
@@ -39,6 +40,7 @@
   <run_depend>moveit_ros_perception</run_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend>moveit_visual_tools</run_depend>
+  <run_depend>rviz_visual_tools</run_depend>
   <run_depend>joy</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_conversions</run_depend>


### PR DESCRIPTION
### Description

This fixes an issue in the motion planning pipeline tutorial where the robot was unable to plan out of an initial state that was in self-collision

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
