### PR TITLE
fix Travis: build from source docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ compiler: gcc
 before_install: # Use this to prepare the system to install prerequisites or dependencies
   # Define some config vars
   - export ROS_DISTRO=melodic
-  - export ROS_REPO=ros
+  - export DOCKER_IMAGE=moveit/moveit:master-source
 
   - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   - export REPOSITORY_NAME=${PWD##*/}


### PR DESCRIPTION
This finally fixes the Travis build, which requires to build against MoveIt `master`, which is not released though. Explicitly specifying to build from the `source` docker container, which has the latest `master` branch built on dockerhub, we ensure that the correct version is used.
This PR depends on the following ones (in the given order):
- [ ] https://github.com/ros-planning/moveit/pull/1451 (provide `source` docker image with `ROS_UNDERLAY` defined)
- [ ] https://github.com/ros-planning/moveit_ci/pull/62 (enable use of `ROS_UNDERLAY` for catkin build)

I tested the interplay of all PRs locally.