### PR TITLE
Move MoveIt_Grasps higher up in index list, before unit tests tutorial

### DIFF
--- a/doc/pick_place/pick_place_tutorial.rst
+++ b/doc/pick_place/pick_place_tutorial.rst
@@ -1,5 +1,5 @@
-Pick and Place Tutorial
-============================
+Pick and Place
+==============
 
 In MoveIt!, grasping is done using the MoveGroup interface. In order to grasp an object we need to create ``moveit_msgs::Grasp`` msg which will allow defining the various poses and postures involved in a grasping operation.
 Watch this video to see the output of this tutorial:

--- a/index.rst
+++ b/index.rst
@@ -46,6 +46,7 @@ Building more complex applications with MoveIt! often requires developers to dig
    doc/time_parameterization/time_parameterization_tutorial
    doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial
    doc/pick_place/pick_place_tutorial
+   doc/moveit_grasps/moveit_grasps_tutorial
 
 Integration with a New Robot
 ----------------------------
@@ -83,7 +84,6 @@ Miscellaneous
    doc/joystick_control_teleoperation/joystick_control_teleoperation_tutorial
    doc/benchmarking/benchmarking_tutorial
    doc/tests/tests_tutorial
-   doc/moveit_grasps/moveit_grasps_tutorial
 
 Attribution
 -----------


### PR DESCRIPTION
Remove redundant 'tutorial' from title of tutorial
