### PR TITLE
Fix no-return warning

### DIFF
--- a/doc/interactivity/include/interactivity/interactive_robot.h
+++ b/doc/interactivity/include/interactivity/interactive_robot.h
@@ -63,7 +63,7 @@ public:
   const std::string& getGroupName() const;
 
   /** Set the pose of the group we are manipulating */
-  bool setGroupPose(const Eigen::Isometry3d& pose);
+  void setGroupPose(const Eigen::Isometry3d& pose);
 
   /** set pose of the world object */
   void setWorldObjectPose(const Eigen::Isometry3d& pose);

--- a/doc/interactivity/src/interactive_robot.cpp
+++ b/doc/interactivity/src/interactive_robot.cpp
@@ -267,7 +267,7 @@ const std::string& InteractiveRobot::getGroupName() const
 }
 
 /* remember new desired robot pose and schedule an update */
-bool InteractiveRobot::setGroupPose(const Eigen::Isometry3d& pose)
+void InteractiveRobot::setGroupPose(const Eigen::Isometry3d& pose)
 {
   desired_group_end_link_pose_ = pose;
   scheduleUpdate();


### PR DESCRIPTION
### Description

Fixing the warning "no return in function returning non-void" by changing the return type to void.
