### PR TITLE
Example Controller Manager in Low Level Controllers, fix

### DIFF
--- a/doc/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/controller_configuration/controller_configuration_tutorial.rst
@@ -115,6 +115,6 @@ There are several options for tuning the behavior and safety checks of the execu
 Example Controller Manager
 --------------------------
 
-MoveIt controller managers, somewhat a misnomer, are the interfaces to your custom low level controllers. A better way to think of them are *controler interfaces*. For most use cases, the included :moveit_codedir:[MoveItSimpleControllerManager](moveit_plugins/moveit_simple_controller_manager) is sufficient if your robot controllers already provide ROS actions for FollowJointTrajectory. If you use *ros_control*, the included :moveit_codedir:[MoveItRosControlInterface](moveit_plugins/moveit_ros_control_interface) is also ideal.
+MoveIt controller managers, somewhat a misnomer, are the interfaces to your custom low level controllers. A better way to think of them are *controler interfaces*. For most use cases, the included :moveit_codedir:`MoveItSimpleControllerManager <moveit_plugins/moveit_simple_controller_manager>` is sufficient if your robot controllers already provide ROS actions for FollowJointTrajectory. If you use *ros_control*, the included :moveit_codedir:`MoveItRosControlInterface <moveit_plugins/moveit_ros_control_interface>` is also ideal.
 
-However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:[here](controller_configuration/src/moveit_controller_manager_example.cpp).
+However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <controller_configuration/src/moveit_controller_manager_example.cpp>`.


### PR DESCRIPTION
### Description

When looking at the current MoveIt tutorial website the page [Low level controllers](http://docs.ros.org/melodic/api/moveit_tutorials/html/doc/controller_configuration/controller_configuration_tutorial.html) it doesn't show the Example Controller Manager paragraph. This paragraph had some minor formatting errors causing it to fail the travis-ci tests in #304 . While the code shows this existing, I bet travis-ci is blocking that section from appearing on the website because of the broken links. Here those links are fixed and this useful addition to the tutorials can become public.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
