### PR TITLE
Master branch: Fix incongrous version number and add to top of every page

### DIFF
--- a/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -19,5 +19,6 @@
       {% endfor %}
     <li>{{ title }}</li>
   </ul>
+  {% include "moveit_version.html" %}
   <hr/>
 </div>

--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,0 +1,5 @@
+<br />
+<div class="admonition note">
+<p class="first admonition-title">Tutorials Version: Master</p>
+<p class="last">This the latest version, which is actively developed. For beginners, we recommmend the stable <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">ROS Melodic tutorials</a>.</p>
+</div>

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -1,8 +1,6 @@
 Getting Started
 ===============
 
-.. note:: You are on the latest **ROS Melodic** version of the tutorials, which is less stable. For beginners we recommmend the more stable `ROS Kinetic tutorials <http://docs.ros.org/kinetic/api/moveit_tutorials/html/index.html>`_ (Requires Ubuntu 16.04). For older computers on Ubuntu 14.04 see `ROS Indigo tutorials with the PR2 <http://docs.ros.org/indigo/api/moveit_tutorials/html/doc/ikfast_tutorial.html>`_.
-
 Install ROS and Catkin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 `Install ROS Melodic <http://wiki.ros.org/melodic/Installation/Ubuntu>`_.

--- a/index.rst
+++ b/index.rst
@@ -8,9 +8,6 @@ These tutorials will step you through using and learning the MoveIt Motion Plann
 
 In these tutorials, the Franka Emika Panda robot is used as a quick-start demo. Alternatively, you can easily use any robot that has already been configured to work with MoveIt - check the `list of robots running MoveIt <http://moveit.ros.org/robots/>`_ to see whether MoveIt is already available for your robot. Otherwise, you can setup MoveIt to work with your custom robot in the tutorial section "Integration with a New Robot", below.
 
-.. note:: You are on the latest **master** version of the tutorials, which is actively developed. For beginners, we recommmend the more stable `ROS Melodic tutorials <http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html>`_ (Requires Ubuntu 18.04). For older computers on Ubuntu 16.04 see `ROS Kinetic tutorials <http://docs.ros.org/kinetic/api/moveit_tutorials/html/>`_.
-
-
 Getting Started with MoveIt and RViz
 -------------------------------------
 .. toctree::


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/561060/59528142-b4be7800-8e9a-11e9-8cf5-e4f4daf7a635.png)

This add the alert box about what version you are on top of every page, and removes it from the two current locations.

It also abstracts the alert into a separate html file, because currently the boxes do not say the same thing (they got out of sync). Code duplication is bad.

My plan after this PR:
- Make the same PR for Melodic, Kinetic, and Indigo branches.