### PR TITLE
Adding tutorial home link melodic

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -98,9 +98,12 @@
       <div class="wy-side-nav-search">
         {% block sidebartitle %}
 
-        <a href="{{ pathto(master_doc) }}">
+        <a href="http://moveit.ros.org">
           <img src="{{ pathto('_static/logo.png', 1) }}"/>
           <span>Planning Framework</span>
+        </a>
+        <a href="{{ pathto(master_doc) }}">
+          <span class="icon icon-home"> MoveIt Tutorials</span>
         </a>
 
         {% include "searchbox.html" %}

--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -100,7 +100,6 @@
 
         <a href="http://moveit.ros.org">
           <img src="{{ pathto('_static/logo.png', 1) }}"/>
-          <span>Planning Framework</span>
         </a>
         <a href="{{ pathto(master_doc) }}">
           <span class="icon icon-home"> MoveIt Tutorials</span>


### PR DESCRIPTION
### Description

*This is functionally identical to #344 but for the melodic branch.*

Most websites have the behavior that if you click on the logo, it returns to the main page of the website. That’s a standard across most websites, and users are used to that. The MoveIt website follows this pattern (on all of the subpages) where if you click the MoveIt logo it returns you to the MoveIt homepage; the one exception, is when you go to the tutorials, which is listed in the MoveIt header navigation, suddenly the behavior changes and clicking on the MoveIt logo does not bring you to the MoveIt website homepage.

This adds that standardized functionality while maintaining the ability to return to the landing page via a new link in the top left.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
