### PR TITLE
build_locally.sh: avoid sudo if possible

### DIFF
--- a/build_locally.sh
+++ b/build_locally.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 
-# TODO: Expand this script to work beyond ROS Kinetic
-
-# Install dependencies
-sudo apt install ros-$ROS_DISTRO-rosdoc-lite
+# Install rosdoc_lite if it isn't there yet
+test -x `which rosdoc_lite` || sudo apt install ros-$ROS_DISTRO-rosdoc-lite
 
 # Setup Environment
 rm -rf build


### PR DESCRIPTION
Usually the `rosdoc_lite` dependency should be installed already.
In this case, it's annoying to ask for the `sudo` password.