### PR TITLE
Install launch files

### DIFF
--- a/doc/move_group_interface/CMakeLists.txt
+++ b/doc/move_group_interface/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(move_group_interface_tutorial src/move_group_interface_tutorial.cpp)
 target_link_libraries(move_group_interface_tutorial ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 install(TARGETS move_group_interface_tutorial DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 


### PR DESCRIPTION
### Description

Update CMakeLists to move this launch file to the correct folder so it can be launched.

I was going through http://docs.ros.org/melodic/api/moveit_tutorials/html/doc/move_group_interface/move_group_interface_tutorial.html building using `colcon` instead of Catkin (unsure if this was also broken for Catkin, it looks like it was) and when running the launch file got:

```
➜  roslaunch moveit_tutorials move_group_interface_tutorial.launch

RLException: [move_group_interface_tutorial.launch] is neither a launch file in package [moveit_tutorials] nor is [moveit_tutorials] a launch file name
The traceback for the exception was written to the log file
```

Running find confirmed that this file was indeed missing:

```
➜  find install -name \*.launch
install/moveit_tutorials/share/moveit_tutorials/launch/ros_api_tutorial.launch
install/moveit_tutorials/share/moveit_tutorials/launch/robot_model_and_robot_state_tutorial.launch
install/moveit_tutorials/share/moveit_tutorials/launch/visualizing_collisions_tutorial.launch
install/moveit_tutorials/share/moveit_tutorials/launch/move_group_python_interface_tutorial.launch
install/moveit_tutorials/share/moveit_tutorials/launch/state_display_tutorial.launch
install/panda_moveit_config/share/panda_moveit_config/launch/move_group.launch
install/panda_moveit_config/share/panda_moveit_config/launch/warehouse.launch
install/panda_moveit_config/share/panda_moveit_config/launch/run_benchmark_ompl.launch
install/panda_moveit_config/share/panda_moveit_config/launch/moveit_rviz.launch
install/panda_moveit_config/share/panda_moveit_config/launch/demo_chomp.launch
install/panda_moveit_config/share/panda_moveit_config/launch/panda_moveit.launch
install/panda_moveit_config/share/panda_moveit_config/launch/demo.launch
install/panda_moveit_config/share/panda_moveit_config/launch/panda_control_moveit_rviz.launch
install/panda_moveit_config/share/panda_moveit_config/launch/joystick_control.launch
install/panda_moveit_config/share/panda_moveit_config/launch/default_warehouse_db.launch
install/panda_moveit_config/share/panda_moveit_config/launch/planning_context.launch
```

The python launch file is there but not C++. 

It looks like the CMakeLists file for this tutorial was missing the line to move the launch file to the share folder so it can be launched with that command. 

After this fix the launch file can be launched correctly. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
