### PR TITLE
Fixing install location of the example plugin xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -54,7 +54,7 @@
 
   <export>
     <!-- An example controller manager plugin for MoveIt. This is not functional code. -->
-    <moveit_core plugin="${prefix}/doc/controller_configuration/moveit_controller_manager_example_plugin_description.xml"/>
+    <moveit_core plugin="${prefix}/moveit_controller_manager_example_plugin_description.xml"/>
   </export>
 
 </package>


### PR DESCRIPTION
### Description

Without this fix the xml install location was incorrectly marked in the package.xml resulting in pluginlib complaining:

```ros.moveit_ros_planning.pluginlib.ClassLoader: Skipped loading plugin with error: XML Document '/home/mike/ws_moveit/install/share/moveit_tutorials/doc/controller_configuration/moveit_controller_manager_example_plugin_description.xml' has no Root Element. This likely means the XML is malformed or missing..```
