### PR TITLE
Fix broken path to moveit_controller_manager_example_plugin_description

### DIFF
--- a/doc/controller_configuration/CMakeLists.txt
+++ b/doc/controller_configuration/CMakeLists.txt
@@ -2,5 +2,6 @@ add_library(controller_manager_example src/moveit_controller_manager_example.cpp
 target_link_libraries(controller_manager_example ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 install(TARGETS controller_manager_example DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+# Need to use non-standard install location to find plugin description both in devel and install space
 install(FILES moveit_controller_manager_example_plugin_description.xml
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/doc/controller_configuration)

--- a/package.xml
+++ b/package.xml
@@ -54,7 +54,7 @@
 
   <export>
     <!-- An example controller manager plugin for MoveIt. This is not functional code. -->
-    <moveit_core plugin="${prefix}/moveit_controller_manager_example_plugin_description.xml"/>
+    <moveit_core plugin="${prefix}/doc/controller_configuration/moveit_controller_manager_example_plugin_description.xml"/>
   </export>
 
 </package>


### PR DESCRIPTION
I introduced this bug a while back when i consolidated the examples from the main moveit repo. This was missing the correct path and outputting an error in terminal.