### PR TITLE
Unified Collision Environment

### DIFF
--- a/doc/visualizing_collisions/src/visualizing_collisions_tutorial.cpp
+++ b/doc/visualizing_collisions/src/visualizing_collisions_tutorial.cpp
@@ -44,8 +44,7 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/planning_scene/planning_scene.h>
-#include <moveit/collision_detection_fcl/collision_world_fcl.h>
-#include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <moveit/collision_detection_fcl/collision_env_fcl.h>
 #include <moveit/collision_detection/collision_tools.h>
 
 planning_scene::PlanningScene* g_planning_scene = 0;


### PR DESCRIPTION
### Description
Replaced `collision_robot` and `collision_world` through the new unified `collision_env`. This goes with [PR #1584 in the main repo](https://github.com/ros-planning/moveit/pull/1584) and allows Travis to build and pass all tests if both are merged together.

This does not build as the main unified PR has to be merged together with this.