### PR TITLE
Update benchmark tutorial: support planning pipelines

### DIFF
--- a/doc/benchmarking/benchmarking_tutorial.rst
+++ b/doc/benchmarking/benchmarking_tutorial.rst
@@ -75,10 +75,9 @@ This class reads in parameters and options for the benchmarks to run from the RO
 
         start_states: [Regex for the stored start states in the warehouse to try]    # Default ""
         path_constraints: [Regex for the path constraints to benchmark]              # Default ""
-
-         queries: [Regex for the motion plan queries in the warehouse to try]        # Default .*
-         goal_constraints: [Regex for the goal constraints to benchmark]             # Default ""
-         trajectory_constraints: [Regex for the trajectory constraints to benchmark] # Default ""
+        queries: [Regex for the motion plan queries in the warehouse to try]         # Default .*
+        goal_constraints: [Regex for the goal constraints to benchmark]              # Default ""
+        trajectory_constraints: [Regex for the trajectory constraints to benchmark]  # Default ""
 
         workspace: [Bounds of the workspace the robot plans in.  This is an AABB]    # Optional
             frame_id: [The frame the workspace parameters are specified in]

--- a/doc/benchmarking/benchmarking_tutorial.rst
+++ b/doc/benchmarking/benchmarking_tutorial.rst
@@ -113,6 +113,12 @@ This is especially useful for benchmarking the effects of smoothing adapters.
 
 It is possible to customize a benchmark run by deriving a class from ``BenchmarkExecutor`` and overriding one or more of the virtual functions.
 For instance, overriding the functions ``initializeBenchmarks()`` or ``loadBenchmarkQueryData()`` allows to specify the benchmark queries directly and to provide a custom planning scene without using ROS warehouse.
+An example is the custom benchmark ``CombinePredefinedPosesBenchmark`` which expects a list of predefined joint states and then creates queries for all pair-wise combinations.
+See the config file ``demo_panda_predefined_poses.yaml`` for how to configure the poses.
+You can run this example with: ::
+
+  roslaunch moveit_ros_benchmarks demo_panda_predefined_poses.launch
+
 Additionally, a set of functions exists for ease of customization in derived classes:
 
 - ``preRunEvent``: invoked immediately before each call to solve

--- a/doc/benchmarking/benchmarking_tutorial.rst
+++ b/doc/benchmarking/benchmarking_tutorial.rst
@@ -1,10 +1,6 @@
 Benchmarking
 =====================
 
-.. note:: This is the new benchmarking method only available in ROS Kinetic, onward.
-
-.. note:: The default method for initializing the planning scene uses the ROS Warehouse plugin. Currently this is not available from Debians and requires a source install for at least some aspects. For source instructions, see `this page <http://moveit.ros.org/install/source/dependencies/>`_
-
 Getting Started
 ---------------
 If you haven't already done so, make sure you've completed the steps in `Getting Started <../getting_started/getting_started.html>`_.

--- a/doc/benchmarking/benchmarking_tutorial.rst
+++ b/doc/benchmarking/benchmarking_tutorial.rst
@@ -109,7 +109,7 @@ Parameters of the BenchmarkExecutor Class
 This class creates a set of ``MotionPlanRequests`` that respect the parameters given in the supplied instance of ``BenchmarkOptions`` and then executes the requests on each of the planners specified.  From the ``BenchmarkOptions``, queries, ``goal_constraints``, and ``trajectory_constraints`` are treated as separate queries.  If a set of ``start_states`` is specified, each query, ``goal_constraint``, and ``trajectory_constraint`` is attempted with each start state (existing start states from a query are ignored).  Similarly, the (optional) set of path constraints is combined combinatorially with the start query and start ``goal_constraint`` pairs (existing ``path_constraint`` from a query are ignored).  The workspace, if specified, overrides any existing workspace parameters.
 
 The benchmarking pipeline does not utilize ``MoveGroup``.
-Instead, the planning pipelines are initialized and run directly including all specified ``PlanningRequestAdaptors``.
+Instead, the planning pipelines are initialized and run directly including all specified ``PlanningRequestAdapters``.
 This is especially useful for benchmarking the effects of smoothing adapters.
 
 It is possible to customize a benchmark run by deriving a class from ``BenchmarkExecutor`` and overriding one or more of the virtual functions.


### PR DESCRIPTION
This updates the benchmarking tutorial to the changes added in https://github.com/ros-planning/moveit/pull/1531 and https://github.com/ros-planning/moveit/pull/1510.

1. Support benchmarking full planning pipelines
2. Describe ROS warehouse as optional