### PR TITLE
Fix URDF typo Universal/Unified

### DIFF
--- a/doc/urdf_srdf/urdf_srdf_tutorial.rst
+++ b/doc/urdf_srdf/urdf_srdf_tutorial.rst
@@ -3,7 +3,7 @@ URDF and SRDF
 
 URDF
 ----
-MoveIt starts with a URDF (Universal Robot Description Format), the native format for describing robots in ROS. In this tutorial, you will find resources for the URDF, important tips and also a list of MoveIt specific requirements.
+MoveIt starts with a URDF (Unified Robot Description Format), the native format for describing robots in ROS. In this tutorial, you will find resources for the URDF, important tips and also a list of MoveIt specific requirements.
 
 URDF Resources
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
### Description

In the documentation, change the explanation of the URDF acronym from **Universal** Robot Description Format to **Unified** Robot Description Format. **Unified** is used in the URDF ROS wiki page (http://wiki.ros.org/urdf). Apparently the use of **Universal** is quite widespread (~2000 Google Search hits, see https://www.google.com/search?q=%22Universal+Robot+Description+Format%22), but the  **Unified** still has more its (~12000 Google Search hits, see https://www.google.com/search?q=%22Unified+Robot+Description+Format%22).

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
