### PR TITLE
Fix link to MoveGroupInterface

### DIFF
--- a/doc/move_group_interface/move_group_interface_tutorial.rst
+++ b/doc/move_group_interface/move_group_interface_tutorial.rst
@@ -56,6 +56,6 @@ The entire launch file is :codedir:`here<move_group_interface/launch/move_group_
 
 A Note on Setting Tolerances
 ----------------------------
-Note that the `MoveGroupInterface's<http://docs.ros.org/melodic/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1MoveGroupInterface.html>` `setGoalTolerance()` and related methods sets the tolerance for **planning**, not execution.
+Note that the `MoveGroupInterface's <http://docs.ros.org/melodic/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1MoveGroupInterface.html>`_ `setGoalTolerance()` and related methods sets the tolerance for **planning**, not execution.
 
 If you want to configure the execution tolerances, you will have to edit the `controller.yaml` file if using a FollowJointTrajectory controller, or manually add it into the generated trajectory message from the planner.


### PR DESCRIPTION
### Description

The link misses an underscore and a whitespace

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
