### PR TITLE
Provide TF buffer to PlanningSceneMonitor

### DIFF
--- a/doc/motion_planning_api/src/motion_planning_api_tutorial.cpp
+++ b/doc/motion_planning_api/src/motion_planning_api_tutorial.cpp
@@ -46,6 +46,7 @@
 #include <moveit_msgs/DisplayTrajectory.h>
 #include <moveit_msgs/PlanningScene.h>
 #include <moveit_visual_tools/moveit_visual_tools.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <boost/scoped_ptr.hpp>
 
@@ -84,10 +85,14 @@ int main(int argc, char** argv)
   // the world (including the robot).
   planning_scene::PlanningScenePtr planning_scene(new planning_scene::PlanningScene(robot_model));
 
+  // For the PlanningSceneMonitor, we need to provide a TransformListener
+  auto tf_buffer = std::make_shared<tf2_ros::Buffer>(ros::Duration(10.0));
+  auto tfl = std::make_shared<tf2_ros::TransformListener>(*tf_buffer, node_handle);
+
   // With the planning scene we create a planing scene monitor that
   // monitors planning scene diffs and applys them to the planning scene
   planning_scene_monitor::PlanningSceneMonitorPtr psm(
-      new planning_scene_monitor::PlanningSceneMonitor(planning_scene, robot_model_loader));
+      new planning_scene_monitor::PlanningSceneMonitor(planning_scene, robot_model_loader, tf_buffer));
   psm->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE);
   psm->startStateMonitor();
   psm->startSceneMonitor();


### PR DESCRIPTION
#273 introduced a PlanningSceneMonitor in the `motion_planning_api_tutorial`. However, as no TF buffer was provided to the PSM, it isn't able to resolve TF frames, which caused a multitude of issues after having switched to a `floating` virtual joint for the Panda robot: 
- https://github.com/ros-planning/panda_moveit_config/issues/33
- https://github.com/ros-planning/panda_moveit_config/issues/38
- https://github.com/ros-planning/moveit_tutorials/issues/312
- https://github.com/ros-planning/moveit/issues/1414

This PR fixes these issues by providing the required TF buffer.
However, thinking more about it, I suggest completely removing the PSM. I will file an appropriate PR.

