### PR TITLE
Fix a typo in controller_configuration_tutorial

### DIFF
--- a/doc/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/controller_configuration/controller_configuration_tutorial.rst
@@ -164,7 +164,7 @@ In order to load an initial pose, one can have a list of (group, pose) pairs as 
 Controller Switching and Namespaces
 -----------------------------------
 
-All controller names get prefixed by the namespace of their ros_control node. For this reason controller names should not contain slashes, and can't be named ``/``. For a particular node MoveIt can decide which controllers to have started or stopped. Since only controller names with registered allocator plugins are handled over MoveIt, MoveIt takes care of stopping controllers based on their claimed resources if a to be started contoller needs any of those resources.
+All controller names get prefixed by the namespace of their ros_control node. For this reason controller names should not contain slashes, and can't be named ``/``. For a particular node MoveIt can decide which controllers to have started or stopped. Since only controller names with registered allocator plugins are handled over MoveIt, MoveIt takes care of stopping controllers based on their claimed resources if a to-be-started controller needs any of those resources.
 
 Controllers for Multiple Nodes
 ------------------------------

--- a/doc/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/controller_configuration/controller_configuration_tutorial.rst
@@ -117,7 +117,7 @@ There are several options for tuning the behavior and safety checks of the execu
 Example Controller Manager
 --------------------------
 
-MoveIt controller managers, somewhat a misnomer, are the interfaces to your custom low level controllers. A better way to think of them are *controler interfaces*. For most use cases, the included :moveit_codedir:`MoveItSimpleControllerManager <moveit_plugins/moveit_simple_controller_manager>` is sufficient if your robot controllers already provide ROS actions for FollowJointTrajectory. If you use *ros_control*, the included :moveit_codedir:`MoveItRosControlInterface <moveit_plugins/moveit_ros_control_interface>` is also ideal.
+MoveIt controller managers, somewhat a misnomer, are the interfaces to your custom low level controllers. A better way to think of them are *controller interfaces*. For most use cases, the included :moveit_codedir:`MoveItSimpleControllerManager <moveit_plugins/moveit_simple_controller_manager>` is sufficient if your robot controllers already provide ROS actions for FollowJointTrajectory. If you use *ros_control*, the included :moveit_codedir:`MoveItRosControlInterface <moveit_plugins/moveit_ros_control_interface>` is also ideal.
 
 However, for some applications you might desire a more custom controller manager. An example template for starting your custom controller manager is provided :codedir:`here <controller_configuration/src/moveit_controller_manager_example.cpp>`.
 

--- a/doc/controller_configuration/controller_configuration_tutorial.rst
+++ b/doc/controller_configuration/controller_configuration_tutorial.rst
@@ -164,7 +164,7 @@ In order to load an initial pose, one can have a list of (group, pose) pairs as 
 Controller Switching and Namespaces
 -----------------------------------
 
-All controller names get prefixed by the namespace of their ros_control node. For this reason controller names should not contain slashes, and can't be named `/`. For a particular node MoveIt can decide which constrollers to have started or stopped. Since only controller names with registered allocator plugins are handled over MoveIt, MoveIt takes care of stopping controllers based on their claimed resources if a to be started contoller needs any of those resources.
+All controller names get prefixed by the namespace of their ros_control node. For this reason controller names should not contain slashes, and can't be named ``/``. For a particular node MoveIt can decide which controllers to have started or stopped. Since only controller names with registered allocator plugins are handled over MoveIt, MoveIt takes care of stopping controllers based on their claimed resources if a to be started contoller needs any of those resources.
 
 Controllers for Multiple Nodes
 ------------------------------


### PR DESCRIPTION
### Description

`controler` in **Example Controller Manager** section should be `controller`

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
