### PR TITLE
clarify version hint [master]

### DIFF
--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,5 +1,5 @@
 <br />
 <div class="admonition note">
 <p class="first admonition-title">Tutorials Version: Master</p>
-<p class="last">This the latest version, which is actively developed. For beginners, we recommmend the stable <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">ROS Melodic tutorials</a>.</p>
+<p class="last">This is the latest version, which is actively developed. For beginners, we recommmend the stable <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a>. If you are still running a Kinetic release, please use the <a class="reference external" href="http://docs.ros.org/kinetic/api/moveit_tutorials/html/index.html">Kinetic tutorials.</a></p>
 </div>


### PR DESCRIPTION
We still frequently see issue reports (e.g. #398) due to users using the wrong version of the tutorials for their ROS release. This is a series of PRs to further clarify the version hint on all tutorial pages.