### PR TITLE
clarify version hint [kinetic]

### DIFF
--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,6 +1,6 @@
 <br />
 <div class="admonition note">
 <p class="first admonition-title">Tutorials Version: Kinetic</p>
-<p class="last">This is the ROS Kinetic version of the tutorials, intended for ROS Kinetic users only.</br>
-  If you are using a ROS Melodic release, we recommmend the <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a> or the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>.
+<p class="last">This is the ROS Kinetic version of the tutorials, intended for ROS Kinetic users only.<br/>
+If you are using a ROS Melodic release, we recommmend the <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a> or the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>.
 </div>

--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,5 +1,6 @@
 <br />
 <div class="admonition note">
 <p class="first admonition-title">Tutorials Version: Kinetic</p>
-<p class="last">This is an older ROS Kinetic LTS version of the tutorials, whose end of life is April 2021. We recommmend the stable <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a> or the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>
+<p class="last">This is the ROS Kinetic version of the tutorials, intended for ROS Kinetic users only.</br>
+  If you are using a ROS Melodic release, we recommmend the <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a> or the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>.
 </div>


### PR DESCRIPTION
We still frequently see issue reports (e.g. #398) due to users using the wrong version of the tutorials for their ROS release. This is a series of PRs to further clarify the version hint on all tutorial pages.