### PR TITLE
clarify version hint [melodic]

### DIFF
--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,5 +1,5 @@
 <br />
 <div class="admonition note">
 <p class="first admonition-title">Tutorials Version: Melodic</p>
-<p class="last">This is the latest release version, Melodic, which is LTS-stable. For advanced developers, we recommmend the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>.</p>
+<p class="last">This is the latest release version, Melodic, which is LTS-stable. For advanced developers, we recommmend the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>. Kinetic users, please use the <a class="reference external" href="http://docs.ros.org/kinetic/api/moveit_tutorials/html/index.html">Kinetic tutorials.</a></p>
 </div>


### PR DESCRIPTION
We still frequently see issue reports (e.g. #398) due to users using the wrong version of the tutorials for their ROS release. This is a series of PRs to further clarify the version hint on all tutorial pages.