### PR TITLE
return int from main()

### DIFF
--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
     std::cin >> character_input;
     if (character_input == 0)
     {
-      return true;
+      return 0;
     }
     else if (character_input == 1)
     {


### PR DESCRIPTION
Fix a warning generated by clang.