### PR TITLE
Fix from kinetic to melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install: # Use this to prepare the system to install prerequisites or dep
   - gem --version
   - gem install html-proofer
   # Install ROS's version of sphinx
-  - sudo apt-get -qq install ros-kinetic-rosdoc-lite
-  - source /opt/ros/kinetic/setup.bash
+  - sudo apt-get -qq install ros-melodic-rosdoc-lite
+  - source /opt/ros/melodic/setup.bash
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci


### PR DESCRIPTION
### Description
I found the mistake on Travis setting.
In the some part of the source, the `kinetic` was used.
So, I fixed it to be `melodic`. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers