### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -38,7 +38,6 @@ To easily follow along with these tutorials, you will need a **ROBOT_moveit_conf
 Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download the tutorials as well as the ``panda_moveit_config`` package: ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit_tutorials.git -b master
   git clone https://github.com/ros-planning/panda_moveit_config.git -b melodic-devel
 
 .. note:: For now we will use a pre-generated ``panda_moveit_config`` package but later we will learn how to make our own in the `MoveIt Setup Assistant tutorial <../setup_assistant/setup_assistant_tutorial.html>`_.


### PR DESCRIPTION
Removed unnecessary line to clone `moveit_tutorials.git` which was already done in the previous `wstool merge`.

This is to remove the issue of user facing:
``` fatal: destination path 'moveit_tutorials' already exists and is not an empty directory.```
while running:
``` git clone https://github.com/ros-planning/moveit_tutorials.git -b master```

Fixes #424.