### PR TITLE
Fixed download of rosinstall

### DIFF
--- a/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
+++ b/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
@@ -26,8 +26,7 @@ Go into your catkin workspace and initialize wstool if necessary (assuming `~/ws
 
 Clone MoveIt Task Constructor and source dependencies: ::
 
-  wget https://raw.githubusercontent.com/ros-planning/moveit_task_constructor/moveit-master/.rosinstall -O moveit_task_constructor.rosinstall
-  wstool merge moveit_task_constructor.rosinstall
+  wstool merge https://raw.githubusercontent.com/ros-planning/moveit_task_constructor/moveit-master/.rosinstall
   wstool update
 
 Install missing packages with rosdep: ::

--- a/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
+++ b/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
@@ -26,8 +26,8 @@ Go into your catkin workspace and initialize wstool if necessary (assuming `~/ws
 
 Clone MoveIt Task Constructor and source dependencies: ::
 
-  git clone https://github.com/ros-planning/moveit_task_constructor.git
-  wstool merge moveit_task_constructor/moveit_task_constructor.rosinstall
+  wget https://raw.githubusercontent.com/ros-planning/moveit_task_constructor/moveit-master/.rosinstall -O moveit_task_constructor.rosinstall
+  wstool merge moveit_task_constructor.rosinstall
   wstool update
 
 Install missing packages with rosdep: ::


### PR DESCRIPTION
### Description

Previously the clone of moveit-master, then merge of rosinstall would modify the branch during the merge and update. It makes more sense to point to the correct file of git for the rosinstall download. It is also more flexible for the future stable branch if such a tutorial will be made for it.

