### PR TITLE
Change install location of moveit_lerp_planner_plugin's plugin description file

### DIFF
--- a/doc/creating_moveit_plugins/lerp_motion_planner/CMakeLists.txt
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/CMakeLists.txt
@@ -60,4 +60,4 @@ install(
 )
 
 install(FILES lerp_interface_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/doc/creating_moveit_plugins/lerp_motion_planner/)


### PR DESCRIPTION
I met this error message when launching a MoveIt rviz plugin:
```shell
Skipped loading plugin with error: XML Document
'/home/yy/ws_moveit/install/share/moveit_tutorials/doc/creating_moveit_plugins/lerp_motion_planner/lerp_interface_plugin_description.xml' has no Root Element. 
This likely means the XML is malformed or missing..
```
Actually, the plugin description file is installed here: `/home/yy/ws_moveit/install/share/moveit_tutorials/lerp_interface_plugin_description.xml`. This PR intends to fix this mismatch.
