### PR TITLE
Clarify how to use perception pipeline without move group

### DIFF
--- a/doc/perception_pipeline/perception_pipeline_tutorial.rst
+++ b/doc/perception_pipeline/perception_pipeline_tutorial.rst
@@ -20,6 +20,8 @@ In this section, we will walk through configuring the 3D sensors on your robot w
 
 * The Depth Image Occupancy Map Updater: which can take as input Depth Images (``sensor_msgs/Image``)
 
+To use the Occupancy Map Updater, it is only necessary to set the appropriate parameters on the ROS parameter server and to call ``startWorldGeometryMonitor`` from your ``PlanningSceneMonitor``.  This latter step is performed automatically when using Move Group functionality like in this tutorial's example, so in that case it is only necessary to set the parameters for the octomap and octomap updater.
+
 YAML Configuration file (Point Cloud)
 +++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
### Description

The perception pipeline tutorial assumes move group is being used without actually mentioning that it makes this assumption, and does not suggest anything to the reader about how to use the functionality without move group.  This PR just adds a segment clarifying that the user must call `startWorldGeometryMonitor` to use the octomap if they are not using move group.

(If maintainers prefer not to have PRs for small modifications like this let me know.  I made a PR because this paragraph would have saved me an hour or so of looking through code)