### PR TITLE
change base link for perception tutorial to world

### DIFF
--- a/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
+++ b/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
@@ -5,7 +5,7 @@
   <node pkg="moveit_tutorials" type="bag_publisher_maintain_time" name="point_clouds" />
 
   <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="to_temp_link" args="0 0.4 -0.6 0 0 0  temp_link panda_link0" />
-  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda_base" args="0 0 0 0 0.2 1.92 camera_rgb_optical_frame temp_link" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_temp_link" args="0 0.4 -0.6 0 0 0  world panda_link0" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda_base" args="0 0 0 0 0.2 1.92 camera_rgb_optical_frame world" />
 
 </launch>


### PR DESCRIPTION
### Description

Fixes the Perception Pipeline Tutorial by correctly changing the base frame for the static transform publishers from `temp_link` to `world`

