### PR TITLE
Bug fix: Following the tutorial, chomp/OptimizerAdapter was added to …

### DIFF
--- a/doc/chomp_planner/chomp_planner_tutorial.rst
+++ b/doc/chomp_planner/chomp_planner_tutorial.rst
@@ -153,6 +153,6 @@ To achieve this, follow the steps:
 
 #. After making these requisite changes to the launch files, open a terminal and execute the following: ::
 
-    roslaunch panda_moveit_config demo_chomp.launch
+    roslaunch panda_moveit_config demo.launch
 
-This will launch RViz, select OMPL in the Motion Planning panel under the Context tab. Set the desired start and goal states by moving the end-effector around in the same way as was done for CHOMP above. Finally click on the Plan button to start planning. The planner will now first run OMPL, then run CHOMP on OMPL's output to produce an optimized path.
+This will launch RViz. Set the desired start and goal states by moving the end-effector around in the same way as was done for CHOMP above. Finally click on the Plan button to start planning. The planner will now first run OMPL, then run CHOMP on OMPL's output to produce an optimized path.


### PR DESCRIPTION
### Description

Bug fix: Following the tutorial, `chomp/OptimizerAdapter` was added to `ompl_planning_pipeline.launch`. Thus, using OMPL as a pre-processor for CHOMP should be done by executing `roslaunch panda_moveit_config demo.launch`. Meanwhile, neither OMPL nor CHOMP can be selected in the `Motion Planning` panel under the Context tab whether you execute `roslaunch panda_moveit_config demo.launch` or `roslaunch panda_moveit_config demo_chomp.launch`. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
