### PR TITLE
Fix webm embedding (#468)

### DIFF
--- a/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -131,10 +131,13 @@ Note what happens when you try to move an end-effector out of its reachable work
 
 Moving Joints or in Null Space
 ++++++++++++++++++++++++++++++
-You can use the **Joints** tab to move single joints and the redundant joints of 7-DOF robots. Try moving the "null space exploration" slider as shown in the animation below.
+You can use the **Joints** tab to move single joints and the redundant joints of 7-DOF robots. Try moving the "null space exploration" slider as shown in this animation.
 
-.. image:: rviz_joints_nullspace.webm
-   :width: 700px
+.. raw:: html
+
+    <div style="position: relative; padding-bottom: 5%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+        <iframe width="700px" height="400px" src="../../../../doc/quickstart_in_rviz/rviz_joints_nullspace.webm" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    </div>
 
 Step 4: Use Motion Planning with the Panda
 -------------------------------------------


### PR DESCRIPTION
This goes towards fixing the formatting issues that caused the webm not to display in #468. It runs with `build_locally.sh`, but I am not sure that it will work online, since the webm file is not copied to the build directory like the images are. I am not sure if Github Pages allows using the [direct link](https://github.com/ros-planning/moveit_tutorials/blob/master/doc/quickstart_in_rviz/rviz_joints_nullspace.webm) to the repo.

If this approach seems off, I'll add a png and a link to the webm. It would be prettier if we had videos, though.

I also found [this](https://github.com/sphinx-contrib/video) sphinx plugin for videos.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers