### PR TITLE
Adapt subframes tutorial

### DIFF
--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -51,8 +51,8 @@
 // Creating the planning request
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 // In this tutorial, we use a small helper function to create our planning requests and move the robot.
-bool moveToCartPose(geometry_msgs::PoseStamped pose, moveit::planning_interface::MoveGroupInterface& group,
-                    std::string end_effector_link)
+bool moveToCartPose(const geometry_msgs::PoseStamped& pose, moveit::planning_interface::MoveGroupInterface& group,
+                    const std::string& end_effector_link)
 {
   // To use subframes of objects that are attached to the robot in planning, you need to set the end effector of your
   // move_group to the subframe of the object. The format has to be ``object_name/subframe_name``, as shown

--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -89,7 +89,7 @@ bool moveToCartPose(geometry_msgs::PoseStamped pose, moveit::planning_interface:
 void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& planning_scene_interface)
 {
   double z_offset_box = .25;  // The z-axis points away from the gripper
-  double z_offset_cylinder = .12;
+  double z_offset_cylinder = .1;
 
   // First, we start defining the `CollisionObject <http://docs.ros.org/api/moveit_msgs/html/msg/CollisionObject.html>`_
   // as usual.

--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -209,22 +209,13 @@ int main(int argc, char** argv)
   // END_SUB_TUTORIAL
 
   // Define a pose in the robot base.
-  tf2::Quaternion orientation, orientation_1, target_orientation;
-  geometry_msgs::PoseStamped fixed_pose, temp_pose_stamped;
+  tf2::Quaternion target_orientation;
+  geometry_msgs::PoseStamped fixed_pose, target_pose;
   fixed_pose.header.frame_id = "panda_link0";
   fixed_pose.pose.position.y = -.4;
   fixed_pose.pose.position.z = .3;
-  orientation.setRPY(0, (-20.0 / 180.0 * M_PI), 0);
-  fixed_pose.pose.orientation = tf2::toMsg(orientation);
-
-  // BEGIN_SUB_TUTORIAL quaternions1
-  // Setting the orientation
-  // ^^^^^^^^^^^^^^^^^^^^^^^
-  // We multiply tf2 quaternions to chain together a few rotations. This is usually simpler and easier
-  // to debug than figuring out a series of euler angles in your head.
-  tf2::Quaternion flip_around_y;  // This is used to rotate the orientation of the target pose.
-  flip_around_y.setRPY(0, (180.0 / 180.0 * M_PI), 0);
-  // END_SUB_TUTORIAL
+  target_orientation.setRPY(0, (-20.0 / 180.0 * M_PI), 0);
+  fixed_pose.pose.orientation = tf2::toMsg(target_orientation);
 
   // Set up a small command line interface to make the tutorial interactive.
   int character_input;
@@ -250,16 +241,18 @@ int main(int argc, char** argv)
     else if (character_input == 1)
     {
       ROS_INFO_STREAM("Moving to bottom of box with cylinder tip");
-      temp_pose_stamped.header.frame_id = "box/bottom";
 
-      // BEGIN_SUB_TUTORIAL quaternions2
-      // When constructing the target pose for the robot, we multiply the quaternions to get the
-      // target orientation and convert the result to a ``geometry_msgs/orientation`` message.
-      orientation_1.setRPY(-(90.0 / 180.0 * M_PI), 0, 0);
-      target_orientation = flip_around_y * orientation_1;
-      temp_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
-      temp_pose_stamped.pose.position.z = 0.01;
-      moveToCartPose(temp_pose_stamped, group, "cylinder/tip");
+      // BEGIN_SUB_TUTORIAL orientation
+      // Setting the orientation
+      // ^^^^^^^^^^^^^^^^^^^^^^^
+      // The target pose is given relative to a box subframe:
+      target_pose.header.frame_id = "box/bottom";
+      // The orientation is determined by RPY angles to align the cylinder and box subframes:
+      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_pose.pose.orientation = tf2::toMsg(target_orientation);
+      // To keep some distance to the box, we use a small offset:
+      target_pose.pose.position.z = 0.01;
+      moveToCartPose(target_pose, group, "cylinder/tip");
       // END_SUB_TUTORIAL
     }
     // BEGIN_SUB_TUTORIAL move_example
@@ -267,41 +260,37 @@ int main(int argc, char** argv)
     else if (character_input == 2)
     {
       ROS_INFO_STREAM("Moving to top of box with cylinder tip");
-      temp_pose_stamped.header.frame_id = "box/top";
-      orientation_1.setRPY((90.0 / 180.0 * M_PI), 0, 0);
-      target_orientation = flip_around_y * orientation_1;
-      temp_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
-      temp_pose_stamped.pose.position.z = 0.01;
-      moveToCartPose(temp_pose_stamped, group, "cylinder/tip");
+      target_pose.header.frame_id = "box/top";
+      target_orientation.setRPY(180.0 / 180.0 * M_PI, 0, 90.0 / 180.0 * M_PI);
+      target_pose.pose.orientation = tf2::toMsg(target_orientation);
+      target_pose.pose.position.z = 0.01;
+      moveToCartPose(target_pose, group, "cylinder/tip");
     }
     // END_SUB_TUTORIAL
     else if (character_input == 3)
     {
-      ROS_INFO_STREAM("Moving to top of box with cylinder tip");
-      temp_pose_stamped.header.frame_id = "box/corner_1";
-      orientation_1.setRPY(-(90.0 / 180.0 * M_PI), 0, 0);
-      target_orientation = flip_around_y * orientation_1;
-      temp_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
-      temp_pose_stamped.pose.position.z = 0.01;
-      moveToCartPose(temp_pose_stamped, group, "cylinder/tip");
+      ROS_INFO_STREAM("Moving to corner1 of box with cylinder tip");
+      target_pose.header.frame_id = "box/corner_1";
+      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_pose.pose.orientation = tf2::toMsg(target_orientation);
+      target_pose.pose.position.z = 0.01;
+      moveToCartPose(target_pose, group, "cylinder/tip");
     }
     else if (character_input == 4)
     {
-      temp_pose_stamped.header.frame_id = "box/corner_2";
-      orientation_1.setRPY(-(90.0 / 180.0 * M_PI), 0, 0);
-      target_orientation = flip_around_y * orientation_1;
-      temp_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
-      temp_pose_stamped.pose.position.z = 0.01;
-      moveToCartPose(temp_pose_stamped, group, "cylinder/tip");
+      target_pose.header.frame_id = "box/corner_2";
+      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_pose.pose.orientation = tf2::toMsg(target_orientation);
+      target_pose.pose.position.z = 0.01;
+      moveToCartPose(target_pose, group, "cylinder/tip");
     }
     else if (character_input == 5)
     {
-      temp_pose_stamped.header.frame_id = "box/side";
-      orientation_1.setRPY(-(90.0 / 180.0 * M_PI), 0, 0);
-      target_orientation = flip_around_y * orientation_1;
-      temp_pose_stamped.pose.orientation = tf2::toMsg(target_orientation);
-      temp_pose_stamped.pose.position.z = 0.01;
-      moveToCartPose(temp_pose_stamped, group, "cylinder/tip");
+      target_pose.header.frame_id = "box/side";
+      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_pose.pose.orientation = tf2::toMsg(target_orientation);
+      target_pose.pose.position.z = 0.01;
+      moveToCartPose(target_pose, group, "cylinder/tip");
     }
     else if (character_input == 6)
     {
@@ -339,8 +328,7 @@ int main(int argc, char** argv)
         co1.operation = moveit_msgs::CollisionObject::REMOVE;
         co2.id = "cylinder";
         co2.operation = moveit_msgs::CollisionObject::REMOVE;
-        std::vector<moveit_msgs::CollisionObject> collision_objects = { co1, co2 };
-        planning_scene_interface.applyCollisionObjects(collision_objects);
+        planning_scene_interface.applyCollisionObjects({ co1, co2 });
       }
       catch (const std::exception& exc)
       {
@@ -389,7 +377,6 @@ int main(int argc, char** argv)
 //
 // CALL_SUB_TUTORIAL move_example
 //
-// CALL_SUB_TUTORIAL quaternions1
-// CALL_SUB_TUTORIAL quaternions2
+// CALL_SUB_TUTORIAL orientation
 //
 // END_TUTORIAL

--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -32,7 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Felix von Drigalski*/
+/* Author: Felix von Drigalski */
 
 // ROS
 #include <ros/ros.h>
@@ -119,35 +119,35 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   box.subframe_poses[0].position.z = 0.0 + z_offset_box;
 
   tf2::Quaternion orientation;
-  orientation.setRPY((90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[0].orientation = tf2::toMsg(orientation);
   // END_SUB_TUTORIAL
 
   box.subframe_names[1] = "top";
   box.subframe_poses[1].position.y = .05;
   box.subframe_poses[1].position.z = 0.0 + z_offset_box;
-  orientation.setRPY(-(90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(-90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[1].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[2] = "corner_1";
   box.subframe_poses[2].position.x = -.025;
   box.subframe_poses[2].position.y = -.05;
   box.subframe_poses[2].position.z = -.01 + z_offset_box;
-  orientation.setRPY((90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[2].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[3] = "corner_2";
   box.subframe_poses[3].position.x = .025;
   box.subframe_poses[3].position.y = -.05;
   box.subframe_poses[3].position.z = -.01 + z_offset_box;
-  orientation.setRPY((90.0 / 180.0 * M_PI), 0, 0);
+  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
   box.subframe_poses[3].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[4] = "side";
   box.subframe_poses[4].position.x = .0;
   box.subframe_poses[4].position.y = .0;
   box.subframe_poses[4].position.z = -.01 + z_offset_box;
-  orientation.setRPY(0, (180.0 / 180.0 * M_PI), 0);
+  orientation.setRPY(0, 180.0 / 180.0 * M_PI, 0);
   box.subframe_poses[4].orientation = tf2::toMsg(orientation);
 
   // Next, define the cylinder
@@ -163,7 +163,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   cylinder.primitive_poses[0].position.x = 0.0;
   cylinder.primitive_poses[0].position.y = 0.0;
   cylinder.primitive_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, (90.0 / 180.0 * M_PI), 0);
+  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
   cylinder.primitive_poses[0].orientation = tf2::toMsg(orientation);
 
   cylinder.subframe_poses.resize(1);
@@ -172,15 +172,14 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   cylinder.subframe_poses[0].position.x = 0.03;
   cylinder.subframe_poses[0].position.y = 0.0;
   cylinder.subframe_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, (90.0 / 180.0 * M_PI), 0);
+  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
   cylinder.subframe_poses[0].orientation = tf2::toMsg(orientation);
 
   // BEGIN_SUB_TUTORIAL object2
   // Lastly, the objects are published to the PlanningScene. In this tutorial, we publish a box and a cylinder.
   box.operation = moveit_msgs::CollisionObject::ADD;
   cylinder.operation = moveit_msgs::CollisionObject::ADD;
-  std::vector<moveit_msgs::CollisionObject> collision_objects = { box, cylinder };
-  planning_scene_interface.applyCollisionObjects(collision_objects);
+  planning_scene_interface.applyCollisionObjects({ box, cylinder });
 }
 // END_SUB_TUTORIAL
 

--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -190,7 +190,6 @@ int main(int argc, char** argv)
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
-  ros::WallDuration(1.0).sleep();
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface;
   moveit::planning_interface::MoveGroupInterface group("panda_arm");
   group.setPlanningTime(10.0);


### PR DESCRIPTION
https://github.com/ros-planning/moveit/pull/1757 fixes `getFrameTransform()` to return global transforms for subframes as well (before, it returned local frames w.r.t. the attach link).
However, this requires some adaptions to the target poses in the subframes tutorial.
I also added visualization of some target and eef frames.

Obviously, depends on https://github.com/ros-planning/moveit/pull/1757