### PR TITLE
moved world frame in perception tutorials

### DIFF
--- a/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
+++ b/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
@@ -5,7 +5,7 @@
   <node pkg="moveit_tutorials" type="bag_publisher_maintain_time" name="point_clouds" />
 
   <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="to_temp_link" args="0 0 0 0 0 0  world panda_link0" />
-  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda_base" args="0.115 0.427 0.570 0 0.2 1.92 camera_rgb_optical_frame world" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda" args="0 0 0 0 0 0  world panda_link0" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_camera" args="0.115 0.427 0.570 0 0.2 1.92 camera_rgb_optical_frame world" />
 
 </launch>

--- a/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
+++ b/doc/perception_pipeline/launch/obstacle_avoidance_demo.launch
@@ -5,7 +5,7 @@
   <node pkg="moveit_tutorials" type="bag_publisher_maintain_time" name="point_clouds" />
 
   <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="to_temp_link" args="0 0.4 -0.6 0 0 0  world panda_link0" />
-  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda_base" args="0 0 0 0 0.2 1.92 camera_rgb_optical_frame world" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_temp_link" args="0 0 0 0 0 0  world panda_link0" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="to_panda_base" args="0.115 0.427 0.570 0 0.2 1.92 camera_rgb_optical_frame world" />
 
 </launch>


### PR DESCRIPTION
### Description

Adjusted the `world` frame in the perception tutorial to coincide with `panda_link0`.

Before:
![before](https://user-images.githubusercontent.com/519268/81593900-54230e00-937d-11ea-84f9-f9f9084ace50.png)
After:
![after](https://user-images.githubusercontent.com/519268/81593898-538a7780-937d-11ea-8352-1609e34617c2.png)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
