### PR TITLE
Creating MoveIt Plugins tutorial: fix namespace collision

### DIFF
--- a/doc/creating_moveit_plugins/lerp_motion_planner/CMakeLists.txt
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/CMakeLists.txt
@@ -8,7 +8,6 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/lerp_interface.cpp
   src/lerp_planning_context.cpp
-  src/lerp_planner_manager.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}  ${catkin_LIBRARIES}  ${Boost_LIBRARIES})
@@ -16,7 +15,6 @@ set_target_properties(${PROJECT_NAME}  PROPERTIES  VERSION  "${${PROJECT_NAME}_V
 
 add_executable(lerp_example  src/lerp_example.cpp)
 target_link_libraries(lerp_example
-  ${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
 )

--- a/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_example.cpp
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_example.cpp
@@ -54,8 +54,6 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
 
-#include <lerp_interface/lerp_planning_context.h>
-
 int main(int argc, char** argv)
 {
   const std::string NODE_NAME = "lerp_example";


### PR DESCRIPTION
### Description

When running the `lerp_example.launch`, I get the following warning:
```
ros.rosconsole_bridge.class_loader.impl: SEVERE WARNING!!! A namespace collision has occured with plugin factory for class lerp_interface::LERPPlannerManager. New factory will OVERWRITE existing one. This situation occurs when libraries containing plugins are directly linked against an executable (the one running right now generating this message). Please separate plugins out into their own library or just don't link against the library and use either class_loader::ClassLoader/MultiLibraryClassLoader to open.
```
I removed the linking of the example with the lerp plugin library, and removed `lerp_planner_manager.cpp` from the main library as it was compiled two times.

In addition the example contained an unused include statement.
```
#include <lerp_interface/lerp_planning_context.h>
```

I think these fixes also make it easier to understand the idea behind plugins. Not having to link it at compile time is the whole point of the plugin infrastructure, as far as I understand it at least.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
