### PR TITLE
Extend constraint manifold tutorial with definition format

### DIFF
--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -33,7 +33,7 @@ You can define these in ``rosparam`` to be loaded together in a file, eg. ``X_mo
      # etc, as described below
 
 JointConstraint
-~~~~~~~~~~~~~~~
+"""""""""""""""
 
 A ``JointConstraint`` limits the positions a joint can take. There are three ways to compactly specify this. 
 
@@ -59,7 +59,7 @@ For example::
    weight: 1.0
 
 PositionConstraint
-~~~~~~~~~~~~~~~~~~
+""""""""""""""""""
 
 A ``PositionConstraint`` constraints the Cartesian positions allowed for a (position relative to a) link. 
 ``target_offset`` is that relative position w.r.t. a link, e.g., the tip of the end-effector relative to its mounting point or other origin definition.
@@ -78,7 +78,8 @@ For example::
    weight: 1.0
    
 OrientationConstraint
-~~~~~~~~~~~~~~~~~~~~~
+"""""""""""""""""""""
+
 
 An ``OrientationConstraint`` can be used to keep eg. something upright (or mostly upright with respect to some tolerance).
 
@@ -92,7 +93,7 @@ It is compactly represented with a list of roll, pitch, yaw and a list of tolera
    weight: 1.0
    
 VisibilityConstraint
-~~~~~~~~~~~~~~~~~~~~
+""""""""""""""""""""
 
 A ``VisibilityConstraint`` allows to eg. specify a camera should always be able to see the gripper.
 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -16,8 +16,95 @@ For more information on how to plan with path constraints in general, take a loo
 Creating the Constraint Database
 --------------------------------
 
-A sample implementation on how to construct an approximation database from a constraint can be found inside ``demo_construct_state_database.cpp``.
+Constructing a Constraints database is done with the `generate_state_database` executable. 
+This loads constraint defintions (in a format explained below) from the ROS parameter server and finally outputs the state database to a given directory. 
 
+Defining constraints
+^^^^^^^^^^^^^^^^^^^^
+The `generate_state_database` executable reads constraints from ROS parameters on `/constraints`, in a more compact format that a complete ROS message. 
+
+JointConstraint
+~~~~~~~~~~~~~~~
+A JointConstraint limits the positions a joint can take. There are three ways to compactly specify this. 
+
+1. position + a single tolerance
+2. position + lower an upper tolerance
+3. upper and lower bound
+
+For example:
+
+ - type: joint
+   joint_name: first_joint
+   position: 0.1
+   tolerance: 0.2
+   weight: 1.0
+ - type: joint
+   joint_name: second_joint
+   position: 0.1
+   tolerances: [0.1, 0.2]
+   weight: 1.0
+ - type: joint
+   joint_name: third_joint
+   bounds: [-0.5, 1.0]
+   weight: 1.0
+
+PositionConstraint
+~~~~~~~~~~~~~~~~~~
+A PositionConstraint constraints the cartesian positions allowed for a (position relative to a) link. 
+``target_offset`` is that relative position wrt. a link, eg. the tip of the end-effector relative to it's mounting point or other origin defintion. 
+This region (boxes only in this compact definition) is compactly defined by specifying the upper and lower bounds along each axis. 
+
+For example:
+
+ - type: position
+   frame_id: base_link
+   link_name: gripper_link
+   target_offset: [0.01, 0.01, 0.01]
+   region:
+     x: [0, 1.0] # [start, end]
+     y: [0, 1.0] # [start, end]
+     z: [0, 1.0] # [start, end]
+   weight: 1.0
+   
+OrientationConstraint
+~~~~~~~~~~~~~~~~~~~~~
+A OrientationConstraint can be used to keep eg. something grasped mostly upright.
+
+It is compactly represented with a list of roll, pitch, yaw and a list of tolerances for each axis, for example:
+
+ - type: orientation
+   frame_id: base_link
+   link_name: gripper_link
+   orientation: [-3.1415269, -1.57079632, 0] #RPY
+   tolerances: [6.28318531, 0.2, 6.28318531]
+   weight: 1.0
+   
+VisibilityConstraint
+~~~~~~~~~~~~~~~~~~~~
+A VisibilityConstraint allows to eg. specify a camera should always be able to see the gripper.
+
+How this is achieved is best explained by the `_VisibilityConstraint
+<https://docs.ros.org/melodic/api/moveit_core/html/classkinematic__constraints_1_1VisibilityConstraint.html#details>` class documentation.
+
+Such a constraint is compactly defined like this:
+
+ - type: visibility
+   target_radius: 0.5
+   target_pose:
+     frame_id: 'base_link'
+     position: [1.2, 3.4, 5.6]
+     orientation: [-3.1415269, -1.57079632, 0] #RPY
+   cone_sides: 4
+   sensor_pose:
+     frame_id: 'gripper_cam_link'
+     position: [1.2, 3.4, 5.6]
+     orientation: [-3.1415269, -1.57079632, 0] #RPY
+   max_view_angle: 1.1
+   max_range_angle: 0.55
+   weight: 1.0
+
+Internals
+^^^^^^^^^
 The main functionality is implemented in the `ConstraintsLibrary <http://docs.ros.org/melodic/api/moveit_planners_ompl/html/classompl__interface_1_1ConstraintsLibrary.html>`_ class.
 
 Constraints are added by calling ``addConstraintApproximation()`` which can be called subsequently to include multiple constraints in the approximation.

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -79,6 +79,7 @@ For example::
    
 OrientationConstraint
 ~~~~~~~~~~~~~~~~~~~~~
+
 An ``OrientationConstraint`` can be used to keep eg. something grasped mostly upright.
 
 It is compactly represented with a list of roll, pitch, yaw and a list of tolerances for each axis, for example::

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -22,7 +22,7 @@ This loads constraint definition (in a format explained below) from the ROS para
 Defining constraints
 ^^^^^^^^^^^^^^^^^^^^
 The ``generate_state_database`` executable reads constraints from ROS parameters on ``/constraints``, in a more compact format that a complete ROS message. 
-You can define these in ``rosparam`` to be loaded together in a file, eg. ::
+You can define these in ``rosparam`` to be loaded together in a file, eg. ``X_moveit_config/config/constraints.yaml``::
 
  path_constraint:
    name: some_constraints
@@ -114,6 +114,10 @@ Running the database generator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Assuming MoveIt itself is already launched (via eg. ``roslaunch X_moveit_config demo.launch``), you can use a launch file similar to `generate_state_database.launch <moveit_planners/ompl/ompl_interface/launch/generate_state_database.launch>`_
+
+The file with the constraint definitions can be passed to the launch file::
+
+ roslaunch ompl_interface generate_state_database.launch constraints_file:=$(rospack find X_moveit_config)/config/constraints.yaml planning_group:=arm
 
 Internals
 ^^^^^^^^^

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -61,7 +61,7 @@ For example::
 PositionConstraint
 ~~~~~~~~~~~~~~~~~~
 
- A ``PositionConstraint`` constraints the Cartesian positions allowed for a (position relative to a) link. 
+A ``PositionConstraint`` constraints the Cartesian positions allowed for a (position relative to a) link. 
 ``target_offset`` is that relative position w.r.t. a link, e.g., the tip of the end-effector relative to its mounting point or other origin definition.
 This region (boxes only in this compact definition) is compactly defined by specifying the upper and lower bounds along each axis. 
 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -126,6 +126,7 @@ The file with the constraint definitions can be passed to the launch file::
 
 Internals
 ^^^^^^^^^
+
 The main functionality is implemented in the `ConstraintsLibrary <http://docs.ros.org/melodic/api/moveit_planners_ompl/html/classompl__interface_1_1ConstraintsLibrary.html>`_ class.
 
 Constraints are added by calling ``addConstraintApproximation()`` which can be called subsequently to include multiple constraints in the approximation.

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -34,6 +34,7 @@ You can define these in ``rosparam`` to be loaded together in a file, eg. ``X_mo
 
 JointConstraint
 ~~~~~~~~~~~~~~~
+
 A ``JointConstraint`` limits the positions a joint can take. There are three ways to compactly specify this. 
 
 1. position + a single tolerance

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -61,7 +61,7 @@ For example::
 PositionConstraint
 ~~~~~~~~~~~~~~~~~~
 
-A ``PositionConstraint`` constraints the cartesian positions allowed for a (position relative to a) link. 
+ A ``PositionConstraint`` constraints the Cartesian positions allowed for a (position relative to a) link. 
 ``target_offset`` is that relative position wrt. a link, eg. the tip of the end-effector relative to it's mounting point or other origin definition. 
 This region (boxes only in this compact definition) is compactly defined by specifying the upper and lower bounds along each axis. 
 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -93,6 +93,7 @@ It is compactly represented with a list of roll, pitch, yaw and a list of tolera
    
 VisibilityConstraint
 ~~~~~~~~~~~~~~~~~~~~
+
 A ``VisibilityConstraint`` allows to eg. specify a camera should always be able to see the gripper.
 
 How this is achieved is best explained by the `VisibilityConstraint <https://docs.ros.org/melodic/api/moveit_core/html/classkinematic__constraints_1_1VisibilityConstraint.html#details>`_ class documentation.

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -118,7 +118,7 @@ Such a constraint is compactly defined like this::
 Running the database generator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Assuming MoveIt itself is already launched (via eg. ``roslaunch X_moveit_config demo.launch``), you can use a launch file similar to `generate_state_database.launch <moveit_planners/ompl/ompl_interface/launch/generate_state_database.launch>`_
+Assuming MoveIt itself is already launched (via eg. ``roslaunch X_moveit_config demo.launch``), you can use a launch file similar to `generate_state_database.launch <https://github.com/ros-planning/moveit/blob/master/moveit_planners/ompl/ompl_interface/launch/generate_state_database.launch>`_
 
 The file with the constraint definitions can be passed to the launch file::
 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -80,7 +80,7 @@ For example::
 OrientationConstraint
 ~~~~~~~~~~~~~~~~~~~~~
 
-An ``OrientationConstraint`` can be used to keep eg. something grasped mostly upright.
+An ``OrientationConstraint`` can be used to keep eg. something upright (or mostly upright with respect to some tolerance).
 
 It is compactly represented with a list of roll, pitch, yaw and a list of tolerances for each axis, for example::
 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -21,6 +21,7 @@ This loads the constraint definition (in a format explained below) from the ROS 
 
 Defining constraints
 ^^^^^^^^^^^^^^^^^^^^
+
 The ``generate_state_database`` executable reads constraints from ROS parameters on ``/constraints``, in a more compact format that a complete ROS message. 
 You can define these in ``rosparam`` to be loaded together in a file, eg. ``X_moveit_config/config/constraints.yaml``::
 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -16,22 +16,30 @@ For more information on how to plan with path constraints in general, take a loo
 Creating the Constraint Database
 --------------------------------
 
-Constructing a Constraints database is done with the `generate_state_database` executable. 
-This loads constraint defintions (in a format explained below) from the ROS parameter server and finally outputs the state database to a given directory. 
+Constructing a Constraints database is done with the ``generate_state_database`` executable. 
+This loads constraint definition (in a format explained below) from the ROS parameter server and finally outputs the state database to a given directory. 
 
 Defining constraints
 ^^^^^^^^^^^^^^^^^^^^
-The `generate_state_database` executable reads constraints from ROS parameters on `/constraints`, in a more compact format that a complete ROS message. 
+The ``generate_state_database`` executable reads constraints from ROS parameters on ``/constraints``, in a more compact format that a complete ROS message. 
+You can define these in ``rosparam`` to be loaded together in a file, eg. ::
+
+ path_constraint:
+   name: some_constraints
+   constraints:
+   - type: orientation
+     frame_id: world
+     # etc, as described below
 
 JointConstraint
 ~~~~~~~~~~~~~~~
-A JointConstraint limits the positions a joint can take. There are three ways to compactly specify this. 
+A ``JointConstraint`` limits the positions a joint can take. There are three ways to compactly specify this. 
 
 1. position + a single tolerance
 2. position + lower an upper tolerance
 3. upper and lower bound
 
-For example:
+For example::
 
  - type: joint
    joint_name: first_joint
@@ -50,11 +58,11 @@ For example:
 
 PositionConstraint
 ~~~~~~~~~~~~~~~~~~
-A PositionConstraint constraints the cartesian positions allowed for a (position relative to a) link. 
-``target_offset`` is that relative position wrt. a link, eg. the tip of the end-effector relative to it's mounting point or other origin defintion. 
+A ``PositionConstraint`` constraints the cartesian positions allowed for a (position relative to a) link. 
+``target_offset`` is that relative position wrt. a link, eg. the tip of the end-effector relative to it's mounting point or other origin definition. 
 This region (boxes only in this compact definition) is compactly defined by specifying the upper and lower bounds along each axis. 
 
-For example:
+For example::
 
  - type: position
    frame_id: base_link
@@ -68,9 +76,9 @@ For example:
    
 OrientationConstraint
 ~~~~~~~~~~~~~~~~~~~~~
-A OrientationConstraint can be used to keep eg. something grasped mostly upright.
+An ``OrientationConstraint`` can be used to keep eg. something grasped mostly upright.
 
-It is compactly represented with a list of roll, pitch, yaw and a list of tolerances for each axis, for example:
+It is compactly represented with a list of roll, pitch, yaw and a list of tolerances for each axis, for example::
 
  - type: orientation
    frame_id: base_link
@@ -81,12 +89,11 @@ It is compactly represented with a list of roll, pitch, yaw and a list of tolera
    
 VisibilityConstraint
 ~~~~~~~~~~~~~~~~~~~~
-A VisibilityConstraint allows to eg. specify a camera should always be able to see the gripper.
+A ``VisibilityConstraint`` allows to eg. specify a camera should always be able to see the gripper.
 
-How this is achieved is best explained by the `_VisibilityConstraint
-<https://docs.ros.org/melodic/api/moveit_core/html/classkinematic__constraints_1_1VisibilityConstraint.html#details>` class documentation.
+How this is achieved is best explained by the `VisibilityConstraint <https://docs.ros.org/melodic/api/moveit_core/html/classkinematic__constraints_1_1VisibilityConstraint.html#details>`_ class documentation.
 
-Such a constraint is compactly defined like this:
+Such a constraint is compactly defined like this::
 
  - type: visibility
    target_radius: 0.5
@@ -102,6 +109,11 @@ Such a constraint is compactly defined like this:
    max_view_angle: 1.1
    max_range_angle: 0.55
    weight: 1.0
+
+Running the database generator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Assuming MoveIt itself is already launched (via eg. ``roslaunch X_moveit_config demo.launch``), you can use a launch file similar to `generate_state_database.launch <moveit_planners/ompl/ompl_interface/launch/generate_state_database.launch>`_
 
 Internals
 ^^^^^^^^^

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -62,7 +62,7 @@ PositionConstraint
 ~~~~~~~~~~~~~~~~~~
 
  A ``PositionConstraint`` constraints the Cartesian positions allowed for a (position relative to a) link. 
-``target_offset`` is that relative position wrt. a link, eg. the tip of the end-effector relative to it's mounting point or other origin definition. 
+``target_offset`` is that relative position w.r.t. a link, e.g., the tip of the end-effector relative to its mounting point or other origin definition.
 This region (boxes only in this compact definition) is compactly defined by specifying the upper and lower bounds along each axis. 
 
 For example::

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -60,6 +60,7 @@ For example::
 
 PositionConstraint
 ~~~~~~~~~~~~~~~~~~
+
 A ``PositionConstraint`` constraints the cartesian positions allowed for a (position relative to a) link. 
 ``target_offset`` is that relative position wrt. a link, eg. the tip of the end-effector relative to it's mounting point or other origin definition. 
 This region (boxes only in this compact definition) is compactly defined by specifying the upper and lower bounds along each axis. 

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -17,7 +17,7 @@ Creating the Constraint Database
 --------------------------------
 
 Constructing a Constraints database is done with the ``generate_state_database`` executable. 
-This loads constraint definition (in a format explained below) from the ROS parameter server and finally outputs the state database to a given directory. 
+This loads the constraint definition (in a format explained below) from the ROS parameter server and outputs the state database to a given directory.
 
 Defining constraints
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This tutorial is out-of-date since https://github.com/ros-planning/moveit/commit/2968865184153581e6e937a78bba86c27800f130. 


### Description

The tutorial is updated to not use the removed `demo_construct_state_database.cpp` but the more generalized version.
This load constraint definitions from a more compact (than a plain ROS message) definition which was previously undocumented. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
