### PR TITLE
replace robot_model and robot_state by moveit::core

### DIFF
--- a/doc/creating_moveit_plugins/lerp_motion_planner/include/lerp_interface/lerp_interface.h
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/include/lerp_interface/lerp_interface.h
@@ -59,8 +59,8 @@ protected:
   int dof_;
 
 private:
-  void interpolate(const std::vector<std::string> joint_names, robot_state::RobotStatePtr& robot_state,
-                   const robot_state::JointModelGroup* joint_model_group, const std::vector<double>& start_joint_vals,
+  void interpolate(const std::vector<std::string> joint_names, moveit::core::RobotStatePtr& robot_state,
+                   const moveit::core::JointModelGroup* joint_model_group, const std::vector<double>& start_joint_vals,
                    const std::vector<double>& goal_joint_vals, trajectory_msgs::JointTrajectory& joint_trajectory);
 };
 }

--- a/doc/creating_moveit_plugins/lerp_motion_planner/include/lerp_interface/lerp_planning_context.h
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/include/lerp_interface/lerp_planning_context.h
@@ -12,7 +12,7 @@ MOVEIT_CLASS_FORWARD(LERPPlanningContext);
 class LERPPlanningContext : public planning_interface::PlanningContext
 {
 public:
-  LERPPlanningContext(const std::string& name, const std::string& group, const robot_model::RobotModelConstPtr& model);
+  LERPPlanningContext(const std::string& name, const std::string& group, const moveit::core::RobotModelConstPtr& model);
   ~LERPPlanningContext() override
   {
   }
@@ -25,7 +25,7 @@ public:
 
 private:
   moveit::core::RobotModelConstPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotStatePtr robot_state_;
   LERPInterfacePtr lerp_interface_;
 };
 

--- a/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_example.cpp
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_example.cpp
@@ -75,16 +75,16 @@ int main(int argc, char** argv)
   psm->startWorldGeometryMonitor();
   psm->startStateMonitor();
 
-  robot_model::RobotModelPtr robot_model = robot_model_loader->getModel();
+  moveit::core::RobotModelPtr robot_model = robot_model_loader->getModel();
 
   // Create a RobotState and to keep track of the current robot pose and planning group
-  robot_state::RobotStatePtr robot_state(
-      new robot_state::RobotState(planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentState()));
+  moveit::core::RobotStatePtr robot_state(
+      new moveit::core::RobotState(planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentState()));
   robot_state->setToDefaultValues();
   robot_state->update();
 
   // Create JointModelGroup
-  const robot_state::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
   const std::vector<std::string>& joint_names = joint_model_group->getActiveJointModelNames();
   const std::vector<std::string>& link_model_names = joint_model_group->getLinkModelNames();
   ROS_INFO_NAMED(NODE_NAME, "end effector name %s\n", link_model_names.back().c_str());

--- a/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_interface.cpp
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_interface.cpp
@@ -63,10 +63,10 @@ bool LERPInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_
   nh_.getParam("num_steps", num_steps_);
 
   ros::WallTime start_time = ros::WallTime::now();
-  robot_model::RobotModelConstPtr robot_model = planning_scene->getRobotModel();
-  robot_state::RobotStatePtr start_state(new robot_state::RobotState(robot_model));
+  moveit::core::RobotModelConstPtr robot_model = planning_scene->getRobotModel();
+  moveit::core::RobotStatePtr start_state(new moveit::core::RobotState(robot_model));
   *start_state = planning_scene->getCurrentState();
-  const robot_state::JointModelGroup* joint_model_group = start_state->getJointModelGroup(req.group_name);
+  const moveit::core::JointModelGroup* joint_model_group = start_state->getJointModelGroup(req.group_name);
   std::vector<std::string> joint_names = joint_model_group->getVariableNames();
   dof_ = joint_names.size();
   std::vector<double> start_joint_values;
@@ -102,8 +102,8 @@ bool LERPInterface::solve(const planning_scene::PlanningSceneConstPtr& planning_
   return true;
 }
 
-void LERPInterface::interpolate(const std::vector<std::string> joint_names, robot_state::RobotStatePtr& rob_state,
-                                const robot_state::JointModelGroup* joint_model_group,
+void LERPInterface::interpolate(const std::vector<std::string> joint_names, moveit::core::RobotStatePtr& rob_state,
+                                const moveit::core::JointModelGroup* joint_model_group,
                                 const std::vector<double>& start_joint_vals, const std::vector<double>& goal_joint_vals,
                                 trajectory_msgs::JointTrajectory& joint_trajectory)
 {

--- a/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_planner_manager.cpp
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_planner_manager.cpp
@@ -52,7 +52,7 @@ public:
   {
   }
 
-  bool initialize(const robot_model::RobotModelConstPtr& model, const std::string& ns) override
+  bool initialize(const moveit::core::RobotModelConstPtr& model, const std::string& ns) override
   {
     for (const std::string& gpName : model->getJointModelGroupNames())
     {

--- a/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_planning_context.cpp
+++ b/doc/creating_moveit_plugins/lerp_motion_planner/src/lerp_planning_context.cpp
@@ -45,7 +45,7 @@
 namespace lerp_interface
 {
 LERPPlanningContext::LERPPlanningContext(const std::string& context_name, const std::string& group_name,
-                                         const robot_model::RobotModelConstPtr& model)
+                                         const moveit::core::RobotModelConstPtr& model)
   : planning_interface::PlanningContext(context_name, group_name), robot_model_(model)
 {
   lerp_interface_ = LERPInterfacePtr(new LERPInterface());
@@ -63,7 +63,7 @@ bool LERPPlanningContext::solve(planning_interface::MotionPlanDetailedResponse& 
         robot_trajectory::RobotTrajectoryPtr(new robot_trajectory::RobotTrajectory(robot_model_, getGroupName()));
 
     moveit::core::RobotState start_state(robot_model_);
-    robot_state::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
+    moveit::core::robotStateMsgToRobotState(res_msg.trajectory_start, start_state);
 
     res.trajectory_[0]->setRobotTrajectoryMsg(start_state, res_msg.trajectory[0]);
     res.description_.push_back("plan");

--- a/doc/creating_moveit_plugins/plugin_tutorial.rst
+++ b/doc/creating_moveit_plugins/plugin_tutorial.rst
@@ -53,8 +53,8 @@ Plugin usage
 
 In this subsection, we explain how to load and use the lerp planner that we have created previously. To this end, a ros node called ``lerp_example.cpp`` is created. The first step is to get the state and  group of joints of the robot that are related to the requested planning group as well as the planning scene by the following lines of code: ::
 
-  robot_state::RobotStatePtr robot_state(new robot_state::RobotState(robot_model));
-  const robot_state::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
+  moveit::core::RobotStatePtr robot_state(new moveit::core::RobotState(robot_model));
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
   const std::vector<std::string>& joint_names = joint_model_group->getVariableNames();
   planning_scene::PlanningScenePtr planning_scene(new planning_scene::PlanningScene(robot_model));
 
@@ -73,7 +73,7 @@ Having the planner loaded, it is time to set the start and goal state for the mo
   req.start_state.joint_state.position = start_joint_values;
 
   // Goal constraint
-  robot_state::RobotState goal_state(robot_model);
+  moveit::core::RobotState goal_state(robot_model);
   std::vector<double> joint_values = { 0.8, 0.7, 1, 1.3, 1.9, 2.2, 3 };
   goal_state.setJointGroupPositions(joint_model_group, joint_values);
   moveit_msgs::Constraints joint_goal = kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group);

--- a/doc/interactivity/include/interactivity/interactive_robot.h
+++ b/doc/interactivity/include/interactivity/interactive_robot.h
@@ -75,12 +75,12 @@ public:
   }
 
   /** access RobotModel */
-  robot_model::RobotModelPtr& robotModel()
+  moveit::core::RobotModelPtr& robotModel()
   {
     return robot_model_;
   }
   /** access RobotState */
-  robot_state::RobotStatePtr& robotState()
+  moveit::core::RobotStatePtr& robotState()
   {
     return robot_state_;
   }
@@ -132,11 +132,11 @@ private:
 
   /* robot info */
   robot_model_loader::RobotModelLoader rm_loader_;
-  robot_model::RobotModelPtr robot_model_;
-  robot_state::RobotStatePtr robot_state_;
+  moveit::core::RobotModelPtr robot_model_;
+  moveit::core::RobotStatePtr robot_state_;
 
   /* info about joint group we are manipulating */
-  const robot_model::JointModelGroup* group_;
+  const moveit::core::JointModelGroup* group_;
   Eigen::Isometry3d desired_group_end_link_pose_;
 
   /* world info */

--- a/doc/interactivity/src/attached_body_tutorial.cpp
+++ b/doc/interactivity/src/attached_body_tutorial.cpp
@@ -164,7 +164,7 @@ int main(int argc, char** argv)
       new ros::Publisher(nh.advertise<visualization_msgs::MarkerArray>("interactive_robot_marray", 100));
 
   // Attach a bar object to the right gripper
-  //  const robot_model::LinkModel *link = robot.robotState()->getLinkModel("r_gripper_palm_link");
+  //  const moveit::core::LinkModel *link = robot.robotState()->getLinkModel("r_gripper_palm_link");
 
   std::vector<shapes::ShapeConstPtr> shapes;
   EigenSTL::vector_Isometry3d poses;
@@ -176,7 +176,7 @@ int main(int argc, char** argv)
   shapes.push_back(bar_shape);
   poses.push_back(Eigen::Isometry3d(Eigen::Translation3d(0.12, 0, 0)));
 
-  const robot_model::JointModelGroup* r_gripper_group = robot.robotModel()->getJointModelGroup("right_gripper");
+  const moveit::core::JointModelGroup* r_gripper_group = robot.robotModel()->getJointModelGroup("right_gripper");
   const std::vector<std::string>& touch_links = r_gripper_group->getLinkModelNames();
 
   robot.robotState()->attachBody("bar", shapes, poses, touch_links, "robot_link8");

--- a/doc/interactivity/src/interactive_robot.cpp
+++ b/doc/interactivity/src/interactive_robot.cpp
@@ -79,7 +79,7 @@ InteractiveRobot::InteractiveRobot(const std::string& robot_description, const s
   }
 
   // create a RobotState to keep track of the current robot pose
-  robot_state_.reset(new robot_state::RobotState(robot_model_));
+  robot_state_.reset(new moveit::core::RobotState(robot_model_));
   if (!robot_state_)
   {
     ROS_ERROR("Could not get RobotState from Model");
@@ -244,7 +244,7 @@ void InteractiveRobot::updateAll()
 // change which group is being manipulated
 void InteractiveRobot::setGroup(const std::string& name)
 {
-  const robot_model::JointModelGroup* group = robot_state_->getJointModelGroup(name);
+  const moveit::core::JointModelGroup* group = robot_state_->getJointModelGroup(name);
   if (!group)
   {
     ROS_ERROR_STREAM("No joint group named " << name);
@@ -277,7 +277,7 @@ void InteractiveRobot::setGroupPose(const Eigen::Isometry3d& pose)
 void InteractiveRobot::publishRobotState()
 {
   moveit_msgs::DisplayRobotState msg;
-  robot_state::robotStateToRobotStateMsg(*robot_state_, msg.state);
+  moveit::core::robotStateToRobotStateMsg(*robot_state_, msg.state);
   robot_state_publisher_.publish(msg);
 }
 

--- a/doc/kinematics/src/ros_api_tutorial.cpp
+++ b/doc/kinematics/src/ros_api_tutorial.cpp
@@ -89,9 +89,9 @@ int main(int argc, char** argv)
 
   /* Filling in a seed state */
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
-  robot_state::RobotStatePtr kinematic_state(new robot_state::RobotState(kinematic_model));
-  const robot_state::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
+  moveit::core::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  moveit::core::RobotStatePtr kinematic_state(new moveit::core::RobotState(kinematic_model));
+  const moveit::core::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
 
   /* Get the names of the joints in the panda_arm*/
   service_request.ik_request.robot_state.joint_state.name = joint_model_group->getJointModelNames();
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
   /* Visualize the result*/
   moveit_msgs::DisplayRobotState msg;
   kinematic_state->setVariableValues(service_response.solution.joint_state);
-  robot_state::robotStateToRobotStateMsg(*kinematic_state, msg.state);
+  moveit::core::robotStateToRobotStateMsg(*kinematic_state, msg.state);
   robot_state_publisher.publish(msg);
 
   // Sleep to let the message go through

--- a/doc/motion_planning_api/src/motion_planning_api_tutorial.cpp
+++ b/doc/motion_planning_api/src/motion_planning_api_tutorial.cpp
@@ -72,10 +72,10 @@ int main(int argc, char** argv)
   //     http://docs.ros.org/indigo/api/moveit_ros_planning/html/classrobot__model__loader_1_1RobotModelLoader.html
   const std::string PLANNING_GROUP = "panda_arm";
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
-  robot_model::RobotModelPtr robot_model = robot_model_loader.getModel();
+  moveit::core::RobotModelPtr robot_model = robot_model_loader.getModel();
   /* Create a RobotState and JointModelGroup to keep track of the current robot pose and planning group*/
-  robot_state::RobotStatePtr robot_state(new robot_state::RobotState(robot_model));
-  const robot_state::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
+  moveit::core::RobotStatePtr robot_state(new moveit::core::RobotState(robot_model));
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
 
   // Using the :moveit_core:`RobotModel`, we can construct a :planning_scene:`PlanningScene`
   // that maintains the state of the world (including the robot).
@@ -224,7 +224,7 @@ int main(int argc, char** argv)
   // Joint Space Goals
   // ^^^^^^^^^^^^^^^^^
   // Now, setup a joint space goal
-  robot_state::RobotState goal_state(robot_model);
+  moveit::core::RobotState goal_state(robot_model);
   std::vector<double> joint_values = { -1.0, 0.7, 0.7, -1.5, -0.7, 2.0, 0.0 };
   goal_state.setJointGroupPositions(joint_model_group, joint_values);
   moveit_msgs::Constraints joint_goal = kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group);

--- a/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -87,17 +87,17 @@ int main(int argc, char** argv)
   psm->startStateMonitor();
 
   /* We can also use the RobotModelLoader to get a robot model which contains the robot's kinematic information */
-  robot_model::RobotModelPtr robot_model = robot_model_loader->getModel();
+  moveit::core::RobotModelPtr robot_model = robot_model_loader->getModel();
 
   /* We can get the most up to date robot state from the PlanningSceneMonitor by locking the internal planning scene
      for reading. This lock ensures that the underlying scene isn't updated while we are reading it's state.
      RobotState's are useful for computing the forward and inverse kinematics of the robot among many other uses */
-  robot_state::RobotStatePtr robot_state(
-      new robot_state::RobotState(planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentState()));
+  moveit::core::RobotStatePtr robot_state(
+      new moveit::core::RobotState(planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentState()));
 
   /* Create a JointModelGroup to keep track of the current robot pose and planning group. The Joint Model
      group is useful for dealing with one set of joints at a time such as a left arm or a end effector */
-  const robot_model::JointModelGroup* joint_model_group = robot_state->getJointModelGroup("panda_arm");
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup("panda_arm");
 
   // We can now setup the PlanningPipeline object, which will use the ROS parameter server
   // to determine the set of request adapters and the planning plugin to use
@@ -197,10 +197,10 @@ int main(int argc, char** argv)
   /* First, set the state in the planning scene to the final state of the last plan */
   robot_state = planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentStateUpdated(response.trajectory_start);
   robot_state->setJointGroupPositions(joint_model_group, response.trajectory.joint_trajectory.points.back().positions);
-  robot_state::robotStateToRobotStateMsg(*robot_state, req.start_state);
+  moveit::core::robotStateToRobotStateMsg(*robot_state, req.start_state);
 
   // Now, setup a joint space goal
-  robot_state::RobotState goal_state(*robot_state);
+  moveit::core::RobotState goal_state(*robot_state);
   std::vector<double> joint_values = { -1.0, 0.7, 0.7, -1.5, -0.7, 2.0, 0.0 };
   goal_state.setJointGroupPositions(joint_model_group, joint_values);
   moveit_msgs::Constraints joint_goal = kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group);
@@ -243,11 +243,11 @@ int main(int argc, char** argv)
   /* First, set the state in the planning scene to the final state of the last plan */
   robot_state = planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentStateUpdated(response.trajectory_start);
   robot_state->setJointGroupPositions(joint_model_group, response.trajectory.joint_trajectory.points.back().positions);
-  robot_state::robotStateToRobotStateMsg(*robot_state, req.start_state);
+  moveit::core::robotStateToRobotStateMsg(*robot_state, req.start_state);
 
   // Now, set one of the joints slightly outside its upper limit
-  const robot_model::JointModel* joint_model = joint_model_group->getJointModel("panda_joint3");
-  const robot_model::JointModel::Bounds& joint_bounds = joint_model->getVariableBounds();
+  const moveit::core::JointModel* joint_model = joint_model_group->getJointModel("panda_joint3");
+  const moveit::core::JointModel::Bounds& joint_bounds = joint_model->getVariableBounds();
   std::vector<double> tmp_values(1, 0.0);
   tmp_values[0] = joint_bounds[0].min_position_ - 0.01;
   robot_state->setJointPositions(joint_model, tmp_values);

--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface;
 
   // Raw pointers are frequently used to refer to the planning group for improved performance.
-  const robot_state::JointModelGroup* joint_model_group =
+  const moveit::core::JointModelGroup* joint_model_group =
       move_group.getCurrentState()->getJointModelGroup(PLANNING_GROUP);
 
   // Visualization
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
   // Note that this will only work if the current state already
   // satisfies the path constraints. So we need to set the start
   // state to a new pose.
-  robot_state::RobotState start_state(*move_group.getCurrentState());
+  moveit::core::RobotState start_state(*move_group.getCurrentState());
   geometry_msgs::Pose start_pose2;
   start_pose2.orientation.w = 1.0;
   start_pose2.position.x = 0.55;

--- a/doc/moveit_cpp/src/moveit_cpp_tutorial.cpp
+++ b/doc/moveit_cpp/src/moveit_cpp_tutorial.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
   // ^^^^^^^
   //
   // Here we will set the current state of the plan using
-  // robot_state::RobotState
+  // moveit::core::RobotState
   auto start_state = *(moveit_cpp_ptr->getCurrentState());
   geometry_msgs::Pose start_pose;
   start_pose.orientation.w = 1.0;
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
   auto plan_solution2 = planning_components->plan();
   if (plan_solution2)
   {
-    robot_state::RobotState robot_state(robot_model_ptr);
+    moveit::core::RobotState robot_state(robot_model_ptr);
     moveit::core::robotStateMsgToRobotState(plan_solution2.start_state, robot_state);
 
     visual_tools.publishText(text_pose, "Start Pose", rvt::WHITE, rvt::XLARGE);
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
   // ^^^^^^^
   //
   // We can also set the goal of the plan using
-  // robot_state::RobotState
+  // moveit::core::RobotState
   auto target_state = *robot_start_state;
   geometry_msgs::Pose target_pose2;
   target_pose2.orientation.w = 1.0;
@@ -160,7 +160,7 @@ int main(int argc, char** argv)
   auto plan_solution3 = planning_components->plan();
   if (plan_solution3)
   {
-    robot_state::RobotState robot_state(robot_model_ptr);
+    moveit::core::RobotState robot_state(robot_model_ptr);
     moveit::core::robotStateMsgToRobotState(plan_solution3.start_state, robot_state);
 
     visual_tools.publishText(text_pose, "Start Pose", rvt::WHITE, rvt::XLARGE);
@@ -196,7 +196,7 @@ int main(int argc, char** argv)
   auto plan_solution4 = planning_components->plan();
   if (plan_solution4)
   {
-    robot_state::RobotState robot_state(robot_model_ptr);
+    moveit::core::RobotState robot_state(robot_model_ptr);
     moveit::core::robotStateMsgToRobotState(plan_solution4.start_state, robot_state);
 
     visual_tools.publishText(text_pose, "Start Pose", rvt::WHITE, rvt::XLARGE);

--- a/doc/planning/src/move_group_tutorial.cpp
+++ b/doc/planning/src/move_group_tutorial.cpp
@@ -106,13 +106,13 @@ int main(int argc, char** argv)
   /* Load the robot model */
   robot_model_loader::RDFLoader robot_model_loader("robot_description");
   /* Get a shared pointer to the model and construct a state */
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
-  robot_state::RobotState current_state(kinematic_model);
+  moveit::core::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  moveit::core::RobotState current_state(kinematic_model);
   current_state.getJointStateGroup("panda_arm")->setToRandomValues();
 
   /* Construct a robot state message */
   moveit_msgs::RobotState robot_state;
-  robot_state::robotStateToRobotStateMsg(current_state, robot_state);
+  moveit::core::robotStateToRobotStateMsg(current_state, robot_state);
 
   /* Construct the service request */
   moveit_msgs::GetStateValidity::Request get_state_validity_request;
@@ -142,7 +142,7 @@ int main(int argc, char** argv)
 
     /* Generate a new state and put it into the request */
     current_state.getJointStateGroup("panda_arm")->setToRandomValues();
-    robot_state::robotStateToRobotStateMsg(current_state, robot_state);
+    moveit::core::robotStateToRobotStateMsg(current_state, robot_state);
     get_state_validity_request.robot_state = robot_state;
     sleep_time.sleep();
   }

--- a/doc/planning_scene/src/planning_scene_tutorial.cpp
+++ b/doc/planning_scene/src/planning_scene_tutorial.cpp
@@ -49,7 +49,7 @@
 // setStateFeasibilityPredicate function. Here's a simple example of a
 // user-defined callback that checks whether the "panda_joint1" of
 // the Panda robot is at a positive or negative angle:
-bool stateFeasibilityTestExample(const robot_state::RobotState& kinematic_state, bool verbose)
+bool stateFeasibilityTestExample(const moveit::core::RobotState& kinematic_state, bool verbose)
 {
   const double* joint_values = kinematic_state.getJointPositions("panda_joint1");
   return (joint_values[0] > 0.0);
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
   // but this method of instantiation is only intended for illustration.
 
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  moveit::core::RobotModelPtr kinematic_model = robot_model_loader.getModel();
   planning_scene::PlanningScene planning_scene(kinematic_model);
 
   // Collision Checking
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
   // the collision_result before making a new collision checking
   // request.
 
-  robot_state::RobotState& current_state = planning_scene.getCurrentStateNonConst();
+  moveit::core::RobotState& current_state = planning_scene.getCurrentStateNonConst();
   current_state.setToRandomPositions();
   collision_result.clear();
   planning_scene.checkSelfCollision(collision_request, collision_result);
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
   // check for directly.
 
   std::vector<double> joint_values = { 0.0, 0.0, 0.0, -2.9, 0.0, 1.4, 0.0 };
-  const robot_model::JointModelGroup* joint_model_group = current_state.getJointModelGroup("panda_arm");
+  const moveit::core::JointModelGroup* joint_model_group = current_state.getJointModelGroup("panda_arm");
   current_state.setJointGroupPositions(joint_model_group, joint_values);
   ROS_INFO_STREAM("Test 4: Current state is "
                   << (current_state.satisfiesBounds(joint_model_group) ? "valid" : "not valid"));
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
   // to the collision checking function.
 
   collision_detection::AllowedCollisionMatrix acm = planning_scene.getAllowedCollisionMatrix();
-  robot_state::RobotState copied_state = planning_scene.getCurrentState();
+  moveit::core::RobotState copied_state = planning_scene.getCurrentState();
 
   collision_detection::CollisionResult::ContactMap::const_iterator it2;
   for (it2 = collision_result.contacts.begin(); it2 != collision_result.contacts.end(); ++it2)

--- a/doc/robot_model_and_robot_state/src/robot_model_and_robot_state_tutorial.cpp
+++ b/doc/robot_model_and_robot_state/src/robot_model_and_robot_state_tutorial.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
   // .. _RobotModelLoader:
   //     http://docs.ros.org/melodic/api/moveit_ros_planning/html/classrobot__model__loader_1_1RobotModelLoader.html
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  moveit::core::RobotModelPtr kinematic_model = robot_model_loader.getModel();
   ROS_INFO("Model frame: %s", kinematic_model->getModelFrame().c_str());
 
   // Using the :moveit_core:`RobotModel`, we can construct a
@@ -78,9 +78,9 @@ int main(int argc, char** argv)
   // :moveit_core:`JointModelGroup`, which represents the robot
   // model for a particular group, e.g. the "panda_arm" of the Panda
   // robot.
-  robot_state::RobotStatePtr kinematic_state(new robot_state::RobotState(kinematic_model));
+  moveit::core::RobotStatePtr kinematic_state(new moveit::core::RobotState(kinematic_model));
   kinematic_state->setToDefaultValues();
-  const robot_state::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
+  const moveit::core::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
 
   const std::vector<std::string>& joint_names = joint_model_group->getVariableNames();
 

--- a/doc/state_display/src/state_display_tutorial.cpp
+++ b/doc/state_display/src/state_display_tutorial.cpp
@@ -62,13 +62,13 @@ int main(int argc, char** argv)
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
 
   /* Get a shared pointer to the model */
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  moveit::core::RobotModelPtr kinematic_model = robot_model_loader.getModel();
 
   /* Create a kinematic state - this represents the configuration for the robot represented by kinematic_model */
-  robot_state::RobotStatePtr kinematic_state(new robot_state::RobotState(kinematic_model));
+  moveit::core::RobotStatePtr kinematic_state(new moveit::core::RobotState(kinematic_model));
 
   /* Get the configuration for the joints in the right arm of the Panda*/
-  const robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
+  const moveit::core::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup("panda_arm");
 
   /* PUBLISH RANDOM ARM POSITIONS */
   ros::NodeHandle nh;
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
 
     /* get a robot state message describing the pose in kinematic_state */
     moveit_msgs::DisplayRobotState msg;
-    robot_state::robotStateToRobotStateMsg(*kinematic_state, msg.state);
+    moveit::core::robotStateToRobotStateMsg(*kinematic_state, msg.state);
 
     /* send the message to the RobotState display */
     robot_state_publisher.publish(msg);
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
 
     /* get a robot state message describing the pose in kinematic_state */
     moveit_msgs::DisplayRobotState msg;
-    robot_state::robotStateToRobotStateMsg(*kinematic_state, msg.state);
+    moveit::core::robotStateToRobotStateMsg(*kinematic_state, msg.state);
 
     /* send the message to the RobotState display */
     robot_state_publisher.publish(msg);

--- a/doc/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/trajopt_planner/src/trajopt_example.cpp
@@ -47,16 +47,16 @@ int main(int argc, char** argv)
   psm->startWorldGeometryMonitor();
   psm->startStateMonitor();
 
-  robot_model::RobotModelPtr robot_model = robot_model_loader->getModel();
+  moveit::core::RobotModelPtr robot_model = robot_model_loader->getModel();
 
   // Create a RobotState to keep track of the current robot pose and planning group
-  robot_state::RobotStatePtr robot_state(
-      new robot_state::RobotState(planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentState()));
+  moveit::core::RobotStatePtr robot_state(
+      new moveit::core::RobotState(planning_scene_monitor::LockedPlanningSceneRO(psm)->getCurrentState()));
   robot_state->setToDefaultValues();
   robot_state->update();
 
   // Create JointModelGroup
-  const robot_state::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
+  const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
   const std::vector<std::string>& joint_names = joint_model_group->getActiveJointModelNames();
   const std::vector<std::string>& link_model_names = joint_model_group->getLinkModelNames();
   ROS_INFO_NAMED(NODE_NAME, "end effector name %s\n", link_model_names.back().c_str());


### PR DESCRIPTION
We should not show users examples with namespaces we do not want to have around anymore.

```
grep -rl robot_model:: | xargs sed -i 's/robot_model::/moveit::core::/g
grep -rl robot_state:: | xargs sed -i 's/robot_state::/moveit::core::/g
```