### PR TITLE
add note to perception tutorial about OpenGL issue with octomaps

### DIFF
--- a/doc/perception_pipeline/perception_pipeline_tutorial.rst
+++ b/doc/perception_pipeline/perception_pipeline_tutorial.rst
@@ -140,7 +140,10 @@ Roslaunch the launch file to run the code directly from moveit_tutorials: ::
 
  roslaunch moveit_tutorials obstacle_avoidance_demo.launch
 
-you should see something like the image shown at the beginning of this tutorial.
+You should see something like the image shown at the beginning of this tutorial.
+If not, you may have run into a `known OpenGL rendering issue <http://wiki.ros.org/rviz/Troubleshooting>`_ that can be fixed by running this command before relaunching the demo: ::
+
+ export LIBGL_ALWAYS_SOFTWARE=1
 
 You can test obstacle avoidance for yourself by setting the goal state manually and then planning and executing. To learn how to do that look at `MoveIt Quickstart in RViz <../quickstart_in_rviz/quickstart_in_rviz_tutorial.html>`_
 

--- a/doc/perception_pipeline/perception_pipeline_tutorial.rst
+++ b/doc/perception_pipeline/perception_pipeline_tutorial.rst
@@ -141,7 +141,7 @@ Roslaunch the launch file to run the code directly from moveit_tutorials: ::
  roslaunch moveit_tutorials obstacle_avoidance_demo.launch
 
 You should see something like the image shown at the beginning of this tutorial.
-If not, you may have run into a `known OpenGL rendering issue <http://wiki.ros.org/rviz/Troubleshooting>`_ that can be fixed by running this command before relaunching the demo: ::
+If not, you may have run into a `known OpenGL rendering issue <http://wiki.ros.org/rviz/Troubleshooting>`_. To work around the issue, you can force CPU-based rendering with this command:
 
  export LIBGL_ALWAYS_SOFTWARE=1
 


### PR DESCRIPTION
### Description

It wasn't obvious to me that the octomaps not rendering could be an OpenGL issue (since everything else seemed to render just fine). This is apparently a known issue, mentioned on the Rviz troubleshooting page, so let's add a note so that someone else doesn't waste a bunch of time like I did.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
