### PR TITLE
Adapt to new moveit_resources layout

### DIFF
--- a/doc/tests/CMakeLists.txt
+++ b/doc/tests/CMakeLists.txt
@@ -1,7 +1,4 @@
 if(CATKIN_ENABLE_TESTING)
-  find_package(moveit_resources REQUIRED)
-  include_directories(${moveit_resources_INCLUDE_DIRS})
-
   catkin_add_gtest(tests_tutorial test/tests.cpp)
   target_link_libraries(tests_tutorial
     ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/package.xml
+++ b/package.xml
@@ -53,7 +53,7 @@
   <run_depend>tf2_eigen</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>
 
-  <test_depend>moveit_resources</test_depend>
+  <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>rosunit</test_depend>
 
   <export>


### PR DESCRIPTION
part of the effort to split moveit_resources into a number of packages.

Related to https://github.com/ros-planning/moveit_resources/pull/36 and https://github.com/ros-planning/moveit/pull/2199