### PR TITLE
Fix the order of planning_adapters

### DIFF
--- a/doc/chomp_planner/chomp_planner_tutorial.rst
+++ b/doc/chomp_planner/chomp_planner_tutorial.rst
@@ -117,12 +117,12 @@ To achieve this, follow the steps:
       <!-- load OMPL planning pipeline, but add the CHOMP planning adapter. -->
       <include file="$(find panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml">
         <arg name="planning_adapters" value="
+           default_planner_request_adapters/AddTimeParameterization
            default_planner_request_adapters/FixWorkspaceBounds
            default_planner_request_adapters/FixStartStateBounds
            default_planner_request_adapters/FixStartStateCollision
            default_planner_request_adapters/FixStartStatePathConstraints
-           chomp/OptimizerAdapter
-           default_planner_request_adapters/AddTimeParameterization"
+           chomp/OptimizerAdapter"
            />
       </include>
       <!-- load chomp config -->

--- a/doc/planning_adapters/planning_adapters_tutorial.rst
+++ b/doc/planning_adapters/planning_adapters_tutorial.rst
@@ -41,12 +41,12 @@ To achieve this, follow the steps:
 #. Open the ``ompl_planning_pipeline.launch`` file in the ``<robot_moveit_config>/launch`` folder of your robot. For the Panda robot it is this `file <https://github.com/ros-planning/panda_moveit_config/blob/melodic-devel/launch/ompl_planning_pipeline.launch.xml>`_. Edit this launch file, find the lines where ``<arg name="planning_adapters">`` is mentioned and change it to: ::
 
     <arg name="planning_adapters"
-         value="default_planner_request_adapters/FixWorkspaceBounds
+         value="default_planner_request_adapters/AddTimeParameterization
+		default_planner_request_adapters/FixWorkspaceBounds
                 default_planner_request_adapters/FixStartStateBounds
                 default_planner_request_adapters/FixStartStateCollision
                 default_planner_request_adapters/FixStartStatePathConstraints
-                chomp/OptimizerAdapter
-                default_planner_request_adapters/AddTimeParameterization" />
+                chomp/OptimizerAdapter" />
 
 #. The values of the ``planning_adapters`` is the order in which the mentioned adapters are called / invoked. Order here matters. Inside the CHOMP adapter, a :moveit_codedir:`call <moveit_planners/chomp/chomp_optimizer_adapter/src/chomp_optimizer_adapter.cpp#L169>` to OMPL is made before invoking the CHOMP optimization solver, so CHOMP takes the initial path computed by OMPL as the starting point to further optimize it. 
 


### PR DESCRIPTION
### Description

Fix the order of planning_adapters.
Add TimeParameterization should be on the top of the list.
See ros-planning/moveit#2053

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
