### PR TITLE
Fix the name of CHOMP optimizer adapter

### DIFF
--- a/doc/planning_adapters/planning_adapters_tutorial.rst
+++ b/doc/planning_adapters/planning_adapters_tutorial.rst
@@ -81,7 +81,7 @@ To achieve this, follow the steps:
                    default_planner_request_adapters/FixStartStateBounds
                    default_planner_request_adapters/FixStartStateCollision
                    default_planner_request_adapters/FixStartStatePathConstraints
-                   default_planner_request_adapters/CHOMPOptimizationAdapter" />
+                   chomp/OptimizerAdapter" />
 
 #. The values of the ``planning_adapters`` is the order in which the mentioned adapters are called / invoked. Order here matters. Inside the CHOMP adapter, a call to STOMP is made before invoking the CHOMP optimization solver, so CHOMP takes the initial path computed by STOMP as the starting point to further optimize it.
 


### PR DESCRIPTION
### Description

Fix the name of CHOMP optimizer adapter. It is renamed by https://github.com/ros-planning/moveit/pull/1251

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
