### PR TITLE
Remove warning about franka_description not being released to Melodic

### DIFF
--- a/doc/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/setup_assistant/setup_assistant_tutorial.rst
@@ -27,12 +27,6 @@ MoveIt and ROS
 
     sudo apt-get install ros-melodic-franka-description
 
-.. note:: Oct 23, 2018: franka_description is `not fully available for ROS Melodic <https://github.com/frankaemika/franka_ros/issues/34>`_.
-
-Until then please manually clone the franka description package: ::
-
-  git clone https://github.com/frankaemika/franka_ros
-
 * If you have the ``panda_moveit_config`` package already git-cloned from the *Getting Started* page, be sure to delete that now since this tutorial will teach you how to create it from scratch: ::
 
    cd ~/ws_moveit/src


### PR DESCRIPTION
### Description

This is just the same commit as the the PR into master cherry-picked into melodic-devel where it also applies.

This warning is irrelevant, `franka_description` was released: https://index.ros.org/p/franka_description/#melodic