### PR TITLE
Add instruction for Kinematic Solver field to the hand planning group to setup assistant tutorial

### DIFF
--- a/doc/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/setup_assistant/setup_assistant_tutorial.rst
@@ -176,6 +176,8 @@ Add the gripper
 
   * Enter *Group Name* as **hand**
 
+  * Let *Kinematic Solver* stay at its default value; **None**.
+
   * Let *Kin. Search Resolution* and *Kin. Search Timeout* stay at their default values.
 
   * Click on the *Add Links* button.


### PR DESCRIPTION
### Description

I noticed this was missing from the instructions.