### PR TITLE
Modifications needed for the tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This repository is currently built automatically by two systems. Travis builds t
 If you want to test the tutorials by generating the html pages locally on your machine, use the ``build_locally`` script.
 It has been tested on Ubuntu 16.04 with ROS Kinetic pre-installed. Run in the root of the moveit_tutorials package:
 
+> **_NOTE:_**  [rosdoc_lite](https://wiki.ros.org/rosdoc_lite) is needed to run the build_locally.sh script!
+
     export ROS_DISTRO=kinetic # 16.04
     export ROS_DISTRO=melodic # 18.04
     export ROS_DISTRO=noetic  # 20.04

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -366,13 +366,13 @@ class MoveGroupPythonIntefaceTutorial(object):
     ##
     ## Adding Objects to the Planning Scene
     ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ## First, we will create a box in the planning scene at the location of the left finger:
+    ## First, we will create a box in the planning scene between the fingers:
     box_pose = geometry_msgs.msg.PoseStamped()
-    box_pose.header.frame_id = "panda_leftfinger"
+    box_pose.header.frame_id = "panda_hand"
     box_pose.pose.orientation.w = 1.0
-    box_pose.pose.position.z = 0.07 # slightly above the end effector
+    box_pose.pose.position.z = 0.11 # above the panda_hand frame
     box_name = "box"
-    scene.add_box(box_name, box_pose, size=(0.1, 0.1, 0.1))
+    scene.add_box(box_name, box_pose, size=(0.075, 0.075, 0.075))
 
     ## END_SUB_TUTORIAL
     # Copy local variables back to class variables. In practice, you should use the class


### PR DESCRIPTION
### Description

Based on  @tylerjw's TODO list from [ros-planning/panda_moveit_config/pull/74#issuecomment-703139739](https://github.com/ros-planning/panda_moveit_config/pull/74#issuecomment-703139739) I started to modify the tutorials in order to fix the broken things.

### Checklist
- ~~[ ] Update video and images for "Move Group C++ Interface"~~
- [X] Fix the position of the box in the "Move Group Python Interface" so it is in between the fingers. -> I shrank the box a little bit to fit between the fingers
- ~~[ ] Update MSA tutorial to include instructions for the default positions of the end effector.~~
- ~~[ ] Clarify the "Example" section of "Benchmarking" to include instructions for the collision scene objects.~~
- ~~[ ] Add instructions to "Benchmarking" for building warehouse_ros_mongo from source until it is released to Noetic.~~
- [X] Add note to tutorials README.md that rosdoc_lite is needed to run the build_locally.sh script.
- ~~[ ] Fix "Planning Scene ROS API" tutorial to spawn the object in the gripper and remove it from the world in the last step.~~
- ~~[ ] Fix "Visualizing Collisions"~~
- ~~[ ] Fix "Subframes" tutorial~~
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [X] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
