### PR TITLE
Fix "Planning Scene ROS API" tutorial

### DIFF
--- a/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
+++ b/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp
@@ -91,23 +91,24 @@ int main(int argc, char** argv)
   // subtract the object from the world
   // and to attach the object to the robot.
   moveit_msgs::AttachedCollisionObject attached_object;
-  attached_object.link_name = "panda_leftfinger";
+  attached_object.link_name = "panda_hand";
   /* The header must contain a valid TF frame*/
-  attached_object.object.header.frame_id = "panda_leftfinger";
+  attached_object.object.header.frame_id = "panda_hand";
   /* The id of the object */
   attached_object.object.id = "box";
 
   /* A default pose */
   geometry_msgs::Pose pose;
+  pose.position.z = 0.11;
   pose.orientation.w = 1.0;
 
   /* Define a box to be attached */
   shape_msgs::SolidPrimitive primitive;
   primitive.type = primitive.BOX;
   primitive.dimensions.resize(3);
-  primitive.dimensions[0] = 0.1;
-  primitive.dimensions[1] = 0.1;
-  primitive.dimensions[2] = 0.1;
+  primitive.dimensions[0] = 0.075;
+  primitive.dimensions[1] = 0.075;
+  primitive.dimensions[2] = 0.075;
 
   attached_object.object.primitives.push_back(primitive);
   attached_object.object.primitive_poses.push_back(pose);
@@ -170,7 +171,7 @@ int main(int argc, char** argv)
   /* First, define the REMOVE object message*/
   moveit_msgs::CollisionObject remove_object;
   remove_object.id = "box";
-  remove_object.header.frame_id = "panda_link0";
+  remove_object.header.frame_id = "panda_hand";
   remove_object.operation = remove_object.REMOVE;
 
   // Note how we make sure that the diff message contains no other
@@ -181,6 +182,7 @@ int main(int argc, char** argv)
   planning_scene.world.collision_objects.clear();
   planning_scene.world.collision_objects.push_back(remove_object);
   planning_scene.robot_state.attached_collision_objects.push_back(attached_object);
+  planning_scene.robot_state.is_diff = true;
   planning_scene_diff_publisher.publish(planning_scene);
 
   visual_tools.prompt("Press 'next' in the RvizVisualToolsGui window to continue the demo");
@@ -194,7 +196,7 @@ int main(int argc, char** argv)
   /* First, define the DETACH object message*/
   moveit_msgs::AttachedCollisionObject detach_object;
   detach_object.object.id = "box";
-  detach_object.link_name = "panda_link8";
+  detach_object.link_name = "panda_hand";
   detach_object.object.operation = attached_object.object.REMOVE;
 
   // Note how we make sure that the diff message contains no other


### PR DESCRIPTION
### Description

Another task taken from @tylerjw's TODO list from [ros-planning/panda_moveit_config/pull/74#](https://github.com/ros-planning/panda_moveit_config/pull/74#issuecomment-703139739). I fixed the "Planning Scene ROS API" tutorial. The adaption of the object's spawn position and size also fixes the removal for me.

While the tutorial does what it should, attaching the object to the arm causes this console output:
```
ros.moveit_core.robot_state: Found empty JointState message
```
Triggered by publishing the planning diff message [here](https://github.com/ros-planning/moveit_tutorials/blob/40bd382c703ffd3dc430d90271ed4c3d1ca3213e/doc/planning_scene_ros_api/src/planning_scene_ros_api_tutorial.cpp#L184).
Any ideas why this happens?
### Checklist
- [X] Solve empty JointState message
- [X] Fix "Planning Scene ROS API" tutorial to spawn the object in the gripper and remove it from the world in the last step.
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)