### PR TITLE
Fixed minor typos in trajopt planner

### DIFF
--- a/doc/trajopt_planner/trajopt_planner_tutorial.rst
+++ b/doc/trajopt_planner/trajopt_planner_tutorial.rst
@@ -61,9 +61,9 @@ Motion planning problem in TrajOpt is defined by a set of cost (COST) and constr
   * `use_time`: Set to `false` value to use a unitless timestep. x1-x0 is the velocity
   * `start_fixed`: Set to `true` to add a constraint for the current joint value
 
-- **InitInfo**: It defines how to initialize the optimization problem by setting a guessed trajectory in a matrix whose number of rows is the same as number of timestpes and whose number of columns is equal to the degrees of freedom. There are three different types for initialization:
+- **InitInfo**: It defines how to initialize the optimization problem by setting a guessed trajectory in a matrix whose number of rows is the same as number of timesteps and whose number of columns is equal to the degrees of freedom. There are three different types for initialization:
 
-  - *STATIONARY*: the initialization matrix has joint values of the current state for all timestpes.
+  - *STATIONARY*: the initialization matrix has joint values of the current state for all timesteps.
 
   - *JOINT_INTERPOLATED*: the initialization matrix is a trajectory interpolated between the current state and the joint state that the user provides for ``data`` member.
 


### PR DESCRIPTION
### Description
Fixed a typo.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
