### PR TITLE
Update catkin install for noetic & python3

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -16,7 +16,7 @@ Once you have ROS installed, make sure you have the most up to date packages: ::
 
 Install `catkin <http://wiki.ros.org/catkin>`_ the ROS build system: ::
 
-  sudo apt-get install ros-melodic-catkin python-catkin-tools
+  sudo apt-get install ros-noetic-catkin python3-catkin-tools
 
 Create A Catkin Workspace and Download MoveIt Source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,6 +55,12 @@ The next command will configure your catkin workspace: ::
   cd ~/ws_moveit
   catkin config --extend /opt/ros/${ROS_DISTRO} --cmake-args -DCMAKE_BUILD_TYPE=Release
   catkin build
+
+.. note:: With the update to noetic and python 3 several dependencies may be missing with the build. Here are some common errors and the commands to fix them:
+  
+  - Missing python 3 dependency\: ``python3-osrf-pycommon`` 
+  - Could not find "controller_manager_msgs"\: ``sudo apt-get install ros-noetic-ros-control ros-noetic-ros-controllers``
+  - Could not find "rosparam_shortcuts"\: ``sudo apt install ros-noetic-rosparam-shortcuts``
 
 Source the catkin workspace: ::
 


### PR DESCRIPTION
### Description

Made two changes to update the getting started page for noetic:

1. Updated the catkin install line to reflect noetic & python 3
2. Added some notes on common errors that can occur from using the noetic script (these are all known errors that MoveIt contributors have commented on).

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
