### PR TITLE
Use tau instead of pi for rotations

### DIFF
--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -181,7 +181,7 @@ int main(int argc, char** argv)
   current_state->copyJointGroupPositions(joint_model_group, joint_group_positions);
 
   // Now, let's modify one of the joints, plan to the new joint space goal and visualize the plan.
-  joint_group_positions[0] = -tau/6;  // -1/6 turn in radians
+  joint_group_positions[0] = -tau / 6;  // -1/6 turn in radians
   move_group.setJointValueTarget(joint_group_positions);
 
   // We lower the allowed maximum velocity and acceleration to 5% of their maximum.

--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -45,6 +45,9 @@
 
 #include <moveit_visual_tools/moveit_visual_tools.h>
 
+// The circle constant tau = 2*pi. One tau is one rotation in radians.
+const double tau = 2 * M_PI;
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "move_group_interface_tutorial");
@@ -178,7 +181,7 @@ int main(int argc, char** argv)
   current_state->copyJointGroupPositions(joint_model_group, joint_group_positions);
 
   // Now, let's modify one of the joints, plan to the new joint space goal and visualize the plan.
-  joint_group_positions[0] = -1.0;  // radians
+  joint_group_positions[0] = -tau/6;  // -1/6 turn in radians
   move_group.setJointValueTarget(joint_group_positions);
 
   // We lower the allowed maximum velocity and acceleration to 5% of their maximum.

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -183,7 +183,7 @@ class MoveGroupPythonInterfaceTutorial(object):
     joint_goal[2] = 0
     joint_goal[3] = -tau/4
     joint_goal[4] = 0
-    joint_goal[5] = tau/6
+    joint_goal[5] = tau/6  # 1/6 of a turn
     joint_goal[6] = 0
 
     # The go command can be called with joint values, poses, or without any

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -52,6 +52,11 @@ import moveit_commander
 import moveit_msgs.msg
 import geometry_msgs.msg
 from math import pi, dist, fabs, cos
+try:
+  from math import tau
+except: # For Python 2 compatibility
+  from math import pi
+  tau = 2.0*pi
 from std_msgs.msg import String
 from moveit_commander.conversions import pose_to_list
 ## END_SUB_TUTORIAL
@@ -168,16 +173,17 @@ class MoveGroupPythonInterfaceTutorial(object):
     ##
     ## Planning to a Joint Goal
     ## ^^^^^^^^^^^^^^^^^^^^^^^^
-    ## The Panda's zero configuration is at a `singularity <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>`_ so the first
-    ## thing we want to do is move it to a slightly better configuration.
-    # We can get the joint values from the group and adjust some of the values:
+    ## The Panda's zero configuration is at a `singularity <https://www.quora.com/Robotics-What-is-meant-by-kinematic-singularity>`_, so the first
+    ## thing we want to do is move it to a slightly better configuration. 
+    ## We use the constant `tau = 2*pi <https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals>`_ for convenience:
+    # We get the joint values from the group and change some of the values:
     joint_goal = move_group.get_current_joint_values()
     joint_goal[0] = 0
-    joint_goal[1] = -pi/4
+    joint_goal[1] = -tau/8
     joint_goal[2] = 0
-    joint_goal[3] = -pi/2
+    joint_goal[3] = -tau/4
     joint_goal[4] = 0
-    joint_goal[5] = pi/3
+    joint_goal[5] = tau/6
     joint_goal[6] = 0
 
     # The go command can be called with joint values, poses, or without any

--- a/doc/pick_place/src/pick_place_tutorial.cpp
+++ b/doc/pick_place/src/pick_place_tutorial.cpp
@@ -155,7 +155,7 @@ void place(moveit::planning_interface::MoveGroupInterface& group)
   // +++++++++++++++++++++++++++
   place_location[0].place_pose.header.frame_id = "panda_link0";
   tf2::Quaternion orientation;
-  orientation.setRPY(0, 0, tau / 4);
+  orientation.setRPY(0, 0, tau / 4);  // A quarter turn about the z-axis
   place_location[0].place_pose.pose.orientation = tf2::toMsg(orientation);
 
   /* For place location, we set the value to the exact location of the center of the object. */

--- a/doc/pick_place/src/pick_place_tutorial.cpp
+++ b/doc/pick_place/src/pick_place_tutorial.cpp
@@ -44,6 +44,9 @@
 // TF2
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
+// The circle constant tau = 2*pi. One tau is one rotation in radians.
+const double tau = 2 * M_PI;
+
 void openGripper(trajectory_msgs::JointTrajectory& posture)
 {
   // BEGIN_SUB_TUTORIAL open_gripper
@@ -94,7 +97,7 @@ void pick(moveit::planning_interface::MoveGroupInterface& move_group)
   // transform from `"panda_link8"` to the palm of the end effector.
   grasps[0].grasp_pose.header.frame_id = "panda_link0";
   tf2::Quaternion orientation;
-  orientation.setRPY(-M_PI / 2, -M_PI / 4, -M_PI / 2);
+  orientation.setRPY(-tau / 4, -tau / 8, -tau / 4);
   grasps[0].grasp_pose.pose.orientation = tf2::toMsg(orientation);
   grasps[0].grasp_pose.pose.position.x = 0.415;
   grasps[0].grasp_pose.pose.position.y = 0;
@@ -152,7 +155,7 @@ void place(moveit::planning_interface::MoveGroupInterface& group)
   // +++++++++++++++++++++++++++
   place_location[0].place_pose.header.frame_id = "panda_link0";
   tf2::Quaternion orientation;
-  orientation.setRPY(0, 0, M_PI / 2);
+  orientation.setRPY(0, 0, tau / 4);
   place_location[0].place_pose.pose.orientation = tf2::toMsg(orientation);
 
   /* For place location, we set the value to the exact location of the center of the object. */

--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -46,6 +46,9 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_eigen/tf2_eigen.h>
 
+// The circle constant tau = 2*pi. One tau is one rotation in radians.
+const double tau = 2 * M_PI;
+
 // BEGIN_SUB_TUTORIAL plan1
 //
 // Creating the planning request
@@ -121,35 +124,35 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   box.subframe_poses[0].position.z = 0.0 + z_offset_box;
 
   tf2::Quaternion orientation;
-  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
+  orientation.setRPY(tau / 4, 0, 0);
   box.subframe_poses[0].orientation = tf2::toMsg(orientation);
   // END_SUB_TUTORIAL
 
   box.subframe_names[1] = "top";
   box.subframe_poses[1].position.y = .05;
   box.subframe_poses[1].position.z = 0.0 + z_offset_box;
-  orientation.setRPY(-90.0 / 180.0 * M_PI, 0, 0);
+  orientation.setRPY(-tau / 4, 0, 0);
   box.subframe_poses[1].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[2] = "corner_1";
   box.subframe_poses[2].position.x = -.025;
   box.subframe_poses[2].position.y = -.05;
   box.subframe_poses[2].position.z = -.01 + z_offset_box;
-  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
+  orientation.setRPY(tau / 4, 0, 0);
   box.subframe_poses[2].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[3] = "corner_2";
   box.subframe_poses[3].position.x = .025;
   box.subframe_poses[3].position.y = -.05;
   box.subframe_poses[3].position.z = -.01 + z_offset_box;
-  orientation.setRPY(90.0 / 180.0 * M_PI, 0, 0);
+  orientation.setRPY(tau / 4, 0, 0);
   box.subframe_poses[3].orientation = tf2::toMsg(orientation);
 
   box.subframe_names[4] = "side";
   box.subframe_poses[4].position.x = .0;
   box.subframe_poses[4].position.y = .0;
   box.subframe_poses[4].position.z = -.01 + z_offset_box;
-  orientation.setRPY(0, 180.0 / 180.0 * M_PI, 0);
+  orientation.setRPY(0, tau / 2, 0);
   box.subframe_poses[4].orientation = tf2::toMsg(orientation);
 
   // Next, define the cylinder
@@ -165,7 +168,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   cylinder.primitive_poses[0].position.x = 0.0;
   cylinder.primitive_poses[0].position.y = 0.0;
   cylinder.primitive_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
+  orientation.setRPY(0, tau / 4, 0);
   cylinder.primitive_poses[0].orientation = tf2::toMsg(orientation);
 
   cylinder.subframe_poses.resize(1);
@@ -174,7 +177,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   cylinder.subframe_poses[0].position.x = 0.03;
   cylinder.subframe_poses[0].position.y = 0.0;
   cylinder.subframe_poses[0].position.z = 0.0 + z_offset_cylinder;
-  orientation.setRPY(0, 90.0 / 180.0 * M_PI, 0);
+  orientation.setRPY(0, tau / 4, 0);
   cylinder.subframe_poses[0].orientation = tf2::toMsg(orientation);
 
   // BEGIN_SUB_TUTORIAL object2
@@ -282,7 +285,7 @@ int main(int argc, char** argv)
   fixed_pose.header.frame_id = "panda_link0";
   fixed_pose.pose.position.y = -.4;
   fixed_pose.pose.position.z = .3;
-  target_orientation.setRPY(0, (-20.0 / 180.0 * M_PI), 0);
+  target_orientation.setRPY(0, (-20.0 / 360.0 * tau), 0);
   fixed_pose.pose.orientation = tf2::toMsg(target_orientation);
 
   // Set up a small command line interface to make the tutorial interactive.
@@ -316,7 +319,7 @@ int main(int argc, char** argv)
       // The target pose is given relative to a box subframe:
       target_pose.header.frame_id = "box/bottom";
       // The orientation is determined by RPY angles to align the cylinder and box subframes:
-      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_orientation.setRPY(0, tau / 2, tau / 4);
       target_pose.pose.orientation = tf2::toMsg(target_orientation);
       // To keep some distance to the box, we use a small offset:
       target_pose.pose.position.z = 0.01;
@@ -330,7 +333,7 @@ int main(int argc, char** argv)
     {
       ROS_INFO_STREAM("Moving to top of box with cylinder tip");
       target_pose.header.frame_id = "box/top";
-      target_orientation.setRPY(180.0 / 180.0 * M_PI, 0, 90.0 / 180.0 * M_PI);
+      target_orientation.setRPY(tau / 2, 0, tau / 4);
       target_pose.pose.orientation = tf2::toMsg(target_orientation);
       target_pose.pose.position.z = 0.01;
       showFrames(target_pose, "cylinder/tip");
@@ -341,7 +344,7 @@ int main(int argc, char** argv)
     {
       ROS_INFO_STREAM("Moving to corner1 of box with cylinder tip");
       target_pose.header.frame_id = "box/corner_1";
-      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_orientation.setRPY(0, tau / 2, tau / 4);
       target_pose.pose.orientation = tf2::toMsg(target_orientation);
       target_pose.pose.position.z = 0.01;
       showFrames(target_pose, "cylinder/tip");
@@ -350,7 +353,7 @@ int main(int argc, char** argv)
     else if (character_input == 4)
     {
       target_pose.header.frame_id = "box/corner_2";
-      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_orientation.setRPY(0, tau / 2, tau / 4);
       target_pose.pose.orientation = tf2::toMsg(target_orientation);
       target_pose.pose.position.z = 0.01;
       showFrames(target_pose, "cylinder/tip");
@@ -359,7 +362,7 @@ int main(int argc, char** argv)
     else if (character_input == 5)
     {
       target_pose.header.frame_id = "box/side";
-      target_orientation.setRPY(0, 180.0 / 180.0 * M_PI, 90.0 / 180.0 * M_PI);
+      target_orientation.setRPY(0, tau / 2, tau / 4);
       target_pose.pose.orientation = tf2::toMsg(target_orientation);
       target_pose.pose.position.z = 0.01;
       showFrames(target_pose, "cylinder/tip");

--- a/doc/subframes/src/subframes_tutorial.cpp
+++ b/doc/subframes/src/subframes_tutorial.cpp
@@ -124,7 +124,7 @@ void spawnCollisionObjects(moveit::planning_interface::PlanningSceneInterface& p
   box.subframe_poses[0].position.z = 0.0 + z_offset_box;
 
   tf2::Quaternion orientation;
-  orientation.setRPY(tau / 4, 0, 0);
+  orientation.setRPY(tau / 4, 0, 0);  // A quarter turn about the x-axis
   box.subframe_poses[0].orientation = tf2::toMsg(orientation);
   // END_SUB_TUTORIAL
 


### PR DESCRIPTION
With Ubuntu 20.04 and Noetic, Python 3.8 has become the default. The circle constant `tau = C/r = 2*pi` has been [added to the Python math module in 3.6](https://www.python.org/dev/peps/pep-0628/).

I don't want to open the whole debate here - [this page](https://tauday.com/tau-manifesto) and [this video](https://www.youtube.com/watch?v=jG7vhMMXagQ&feature=youtu.be&ab_channel=Vihart) should summarize the arguments well enough. In short, it is an extremely useful representation for robotics, because we constantly write rotations using radians, and using tau saves mental operations. Although rotating around an axis is not difficult to do, chaining rotations in your head is confusing enough that Robert made [this helper tool](https://github.com/ubi-agni/agni_tf_tools) and I keep using [this one](http://46.101.206.60/rotate). Something as seemingly simple as multiplying by (or was it dividing by?) 2 to describe a rotation is similarly "not difficult, but still confusing". We should not have unnecessary confusions in our way.

The natural way we think of rotations is in full turns. Just consider [this part of the tutorial](https://ros-planning.github.io/moveit_tutorials/doc/move_group_python_interface/move_group_python_interface_tutorial.html#planning-to-a-joint-goal) where we define joint angles. Try to imagine the configuration of this robot in your head*: 

```
joint_goal[0] = 0
joint_goal[1] = -pi/4
joint_goal[2] = 0
joint_goal[3] = -pi/2
joint_goal[4] = 0
joint_goal[5] = pi/3
joint_goal[6] = 0
```

Now try to do it with this description, remembering that one tau is one turn, as per this outrageously simple diagram:

![image](https://user-images.githubusercontent.com/4535737/98917678-05168b00-2510-11eb-878a-42997d1eb7f7.png)

```
joint_goal[0] = 0
joint_goal[1] = -tau/8
joint_goal[2] = 0
joint_goal[3] = -tau/4
joint_goal[4] = 0
joint_goal[5] = tau/6
joint_goal[6] = 0
```

Did converting the angles in your head give you the slightest bit of pause? Likely not much, since as I said, it isn't *difficult*. But that's because dealing with these numbers all the time is literally our job. It is much more cumbersome for anyone who starts out, and this layer of obfuscation serves no use.

I am convinced that using "1 turn" as the unit for rotations makes writing rotations in radians a ton easier. I have started using it myself and have no idea why I hadn't done so earlier. It is just the weight of convention\*\*.

Converting is trivial, as this affects only 3 files, and there is no need to change anything in the main code base. This is just introducing a useful shorthand in our educational materials, for users who would benefit from seeing it. There is precedent for saying "I'm just going to do this" in 
[this somewhat amusing discussion of the issue](https://bugs.python.org/issue12345). I think we should follow this example.

This works on Python 2.7 since I guarded the Python include, so it can be backported to Melodic and Kinetic.

Pinging @tylerjw and @DLu  since they've been working on the tutorials.

\* I know robot configurations are already hard to imagine because the axes inconveniently switch signs, but you get the point.  
\*\* Actually I was expressing all rotations in degrees because it was so annoying to do the conversion in my head.

**edit:** This issue is a little controversial, so if you could add a reaction to this post (:+1: , :confused: or :-1:) on this post, that will be helpful.