### PR TITLE
switch to bionic for htmlproofer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Test build the MoveIt tutorials. Author: Dave Coleman
 sudo: required
-dist: xenial
+dist: bionic
 language: ruby
 rvm:
   - 2.4

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -17,8 +17,8 @@ gem update --system
 gem --version
 gem install html-proofer
 # Install ROS's version of sphinx
-sudo apt-get -qq install ros-kinetic-rosdoc-lite
-source /opt/ros/kinetic/setup.bash
+sudo apt-get -qq install ros-melodic-rosdoc-lite
+source /opt/ros/melodic/setup.bash
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
 sphinx-build -W -b html . native_build


### PR DESCRIPTION
because of dependency issue:
The last version of parallel (~> 1.3) to support your Ruby & RubyGems was 1.19.2
parallel requires Ruby version >= 2.5. The current ruby version is 2.4.10.364

### Description

See failing [travis job](https://travis-ci.com/github/ros-planning/moveit_tutorials/jobs/439284987).

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)

