### PR TITLE
Add version buttons and indicator in sidebar header

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -101,7 +101,17 @@
         <a href="http://moveit.ros.org">
           <img src="{{ pathto('_static/logo.png', 1) }}"/>
         </a>
-
+        
+        <div class="version">
+          <div class="version-dropdown">
+          <select class="version-list" id="version-list" onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+              <option value=''>{{ version }}</option>
+              <option value="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">Melodic</option>
+              <option value="http://docs.ros.org/en/kinetic/api/moveit_tutorials/html/index.html">Kinetic</option>
+              <option value="http://docs.ros.org/en/indigo/api/moveit_tutorials/html/index.html">Indigo</option>
+          </select>
+          </div>
+        </div><br>
         {% include "searchbox.html" %}
 
         {% endblock %}
@@ -153,12 +163,9 @@
       </div>
 
     </section>
-
   </div>
-  {% include "versions.html" %}
-
+  
   {% if not embedded %}
-
     <script type="text/javascript">
         var DOCUMENTATION_OPTIONS = {
             URL_ROOT:'{{ url_root }}',

--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -104,11 +104,12 @@
         
         <div class="version">
           <div class="version-dropdown">
+            <lable for="version-list">Version:</lable>
           <select class="version-list" id="version-list" onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
               <option value=''>{{ version }}</option>
               <option value="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">Melodic</option>
               <option value="http://docs.ros.org/en/kinetic/api/moveit_tutorials/html/index.html">Kinetic</option>
-              <option value="http://docs.ros.org/en/indigo/api/moveit_tutorials/html/index.html">Indigo</option>
+              <option value="http://docs.ros.org/en/indigo/api/moveit_tutorials/html/index.html">Indigo (EOL)</option>
           </select>
           </div>
         </div><br>

--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,5 +1,5 @@
 <br />
 <div class="admonition note">
-<p class="first admonition-title">Tutorials Version: Master</p>
-<p class="last">This is the latest version, which is actively developed. For beginners, we recommmend the stable <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a>. If you are still running a Kinetic release, please use the <a class="reference external" href="http://docs.ros.org/kinetic/api/moveit_tutorials/html/index.html">Kinetic tutorials.</a></p>
+<p class="first admonition-title">Tutorials Version: Noetic</p>
+<p class="last">This is the latest version, which is actively developed and best for beginners. If you are still running a Melotic release, please use the <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a>.</p>
 </div>

--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,5 +1,5 @@
 <br />
 <div class="admonition note">
 <p class="first admonition-title">Tutorials Version: Noetic</p>
-<p class="last">This is the latest version, which is actively developed and best for beginners. If you are still running a Melotic release, please use the <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a>.</p>
+<p class="last">This is the latest version, which is actively developed and best for beginners. If you are still running a Melodic release, please use the <a class="reference external" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html">Melodic tutorials</a>.</p>
 </div>

--- a/_themes/sphinx_rtd_theme/versions.html
+++ b/_themes/sphinx_rtd_theme/versions.html
@@ -1,37 +1,23 @@
-{% if READTHEDOCS %}
+
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> Read the Docs</span>
-      v: {{ current_version }}
+      <span class="fa fa-book"> MoveIt</span>
+      v: {{ version }}
       <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">
       <dl>
-        <dt>Versions</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
-        {% endfor %}
-      </dl>
+        <dt>Current Versions</dt>
+        <dd><a href="https://ros-planning.github.io/moveit_tutorials/">Noetic</a></dd>
+        <dd><a href="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">Melodic</a></dd>
+              </dl>
       <dl>
-        <dt>Downloads</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
+        <dt>Old Versions</dt>
+        <dd><a href="http://docs.ros.org/en/kinetic/api/moveit_tutorials/html/index.html">Kinetic</a></dd>
+        <dd><a href="http://docs.ros.org/en/indigo/api/moveit_tutorials/html/index.html">Indigo</a></dd>
       </dl>
-      <dl>
-        <dt>On Read the Docs</dt>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">Project Home</a>
-          </dd>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">Builds</a>
-          </dd>
-      </dl>
-      <hr/>
-      Free document hosting provided by <a href="http://www.readthedocs.org">Read the Docs</a>.
-
     </div>
   </div>
-{% endif %}
+
 


### PR DESCRIPTION
### Description

Added a version drop-down menu to the top of the nav bar. Also updated wording for version notice at top.

Version pop-out at bottom of sidebar was also updated, but is not being used right now. 
If this gets merged I can add the same thing to older versions of documentation.

![version-dropdown](https://user-images.githubusercontent.com/1692751/100803440-65e70400-33e8-11eb-95bb-67116953b066.gif)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
