### PR TITLE
Update move groupe c++ interface doc

### DIFF
--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -227,10 +227,9 @@ int main(int argc, char** argv)
   // generative sampler.
   //
   // By enforcing ``joint space`` the planning process will use rejection 
-  // sampling to find valid requests. Please not that this might 
+  // sampling to find valid requests. Please note that this might 
   // increase planning time considerably.
-
-
+  //
   // We will reuse the old goal that we had and plan to it.
   // Note that this will only work if the current state already
   // satisfies the path constraints. So we need to set the start

--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -217,17 +217,17 @@ int main(int argc, char** argv)
   // Enforce Planning in Joint Space
   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //
-  // Depending on the planning problem MoveIt chooses between 
-  // ``joint space`` and ``cartesian space`` for problem representation. 
+  // Depending on the planning problem MoveIt chooses between
+  // ``joint space`` and ``cartesian space`` for problem representation.
   // Setting the group parameter ``enforce_joint_model_state_space:true`` in
   // the ompl_planning.yaml file enforces the use of ``joint space`` for all plans.
   //
-  // By default planning requests with orientation path constraints 
-  // are sampled in ``cartesian space`` so that invoking IK serves as a 
+  // By default planning requests with orientation path constraints
+  // are sampled in ``cartesian space`` so that invoking IK serves as a
   // generative sampler.
   //
-  // By enforcing ``joint space`` the planning process will use rejection 
-  // sampling to find valid requests. Please note that this might 
+  // By enforcing ``joint space`` the planning process will use rejection
+  // sampling to find valid requests. Please note that this might
   // increase planning time considerably.
   //
   // We will reuse the old goal that we had and plan to it.

--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -214,6 +214,23 @@ int main(int argc, char** argv)
   test_constraints.orientation_constraints.push_back(ocm);
   move_group.setPathConstraints(test_constraints);
 
+  // Enforce Planning in Joint Space
+  // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //
+  // Depending on the planning problem MoveIt chooses between 
+  // ``joint space`` and ``cartesian space`` for problem representation. 
+  // Setting the group parameter ``enforce_joint_model_state_space:true`` in
+  // the ompl_planning.yaml file enforces the use of ``joint space`` for all plans.
+  //
+  // By default planning requests with orientation path constraints 
+  // are sampled in ``cartesian space`` so that invoking IK serves as a 
+  // generative sampler.
+  //
+  // By enforcing ``joint space`` the planning process will use rejection 
+  // sampling to find valid requests. Please not that this might 
+  // increase planning time considerably.
+
+
   // We will reuse the old goal that we had and plan to it.
   // Note that this will only work if the current state already
   // satisfies the path constraints. So we need to set the start


### PR DESCRIPTION
### Description
Took me ages to realize that it's necessary to enforce the joint_model_state_space when using orientation path constraints in close proximity to the robot's base link.

Give reference to the fact that in some cases one has to enforce the joint_model_state_space.