### PR TITLE
Add comment about the importance of AsyncSpinner

### DIFF
--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -49,6 +49,10 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "move_group_interface_tutorial");
   ros::NodeHandle node_handle;
+  
+  // ROS spinning must be running for the MoveGroupInterface to get information
+  // about the robot's state. One way to do this is to start an AsyncSpinner
+  // beforehand.
   ros::AsyncSpinner spinner(1);
   spinner.start();
 

--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "move_group_interface_tutorial");
   ros::NodeHandle node_handle;
-  
+
   // ROS spinning must be running for the MoveGroupInterface to get information
   // about the robot's state. One way to do this is to start an AsyncSpinner
   // beforehand.


### PR DESCRIPTION
will prevent others from wasting hours trying to debug why the code snippets they borrowed from this tutorial do not work. Covers
- the case mentioned [in this ROS answer](https://answers.ros.org/question/302283/failed-to-fetch-current-robot-state/?answer=348497#post-id-348497)
- the common case where `move_group` and `joint_model_group` are class variables and initialized in a constructor

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
