### PR TITLE
Tiny change

### DIFF
--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -156,9 +156,10 @@ int main(int argc, char** argv)
   // a blocking function and requires a controller to be active
   // and report success on execution of a trajectory.
 
-  /* Uncomment below line when working with a real robot */
-  /* move_group.move(); */
-
+  /* Uncomment ONE of the two below lines when working with a real robot */
+  // move_group.execute(my_plan);  //<-- executes the plan you just made (will be the same as the above visualized trajectory)
+  // move_group.move(); 	    //<-- replans and executes (will likely be differently than the above visualized trajectory)
+  
   // Planning to a joint-space goal
   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //


### PR DESCRIPTION
### Changed commented out line to use move_group.execute(my_plan) instead of move_group.move()

This is a very nit-picky little change, but it tripped me up for several hours as a new user. If you use move_group.move() instead of execute() you will very likely execute a different trajectory than what you planned and visualized.

### Checklist
- [ x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
