### PR TITLE
Update move_group_python_interface_tutorial.py

### DIFF
--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -79,7 +79,7 @@ def all_close(goal, actual, tolerance):
   elif type(goal) is geometry_msgs.msg.Pose:
     x0, y0, z0, qx0, qy0, qz0, qw0 = pose_to_list(actual)
     x1, y1, z1, qx1, qy1, qz1, qw1 = pose_to_list(goal)
-    # Euclidian distance
+    # Euclidean distance
     d = dist((x1, y1, z1), (x0, y0, z0))
     # phi = angle between orientations
     cos_phi_half = fabs(qx0*qx1 + qy0*qy1 + qz0*qz1 + qw0*qw1)
@@ -88,10 +88,10 @@ def all_close(goal, actual, tolerance):
   return True
 
 
-class MoveGroupPythonIntefaceTutorial(object):
-  """MoveGroupPythonIntefaceTutorial"""
+class MoveGroupPythonInterfaceTutorial(object):
+  """MoveGroupPythonInterfaceTutorial"""
   def __init__(self):
-    super(MoveGroupPythonIntefaceTutorial, self).__init__()
+    super(MoveGroupPythonInterfaceTutorial, self).__init__()
 
     ## BEGIN_SUB_TUTORIAL setup
     ##
@@ -468,7 +468,7 @@ def main():
     print("Press Ctrl-D to exit at any time")
     print("")
     input("============ Press `Enter` to begin the tutorial by setting up the moveit_commander ...")
-    tutorial = MoveGroupPythonIntefaceTutorial()
+    tutorial = MoveGroupPythonInterfaceTutorial()
 
     input("============ Press `Enter` to execute a movement using a joint state goal ...")
     tutorial.go_to_joint_state()

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -59,7 +59,9 @@ from moveit_commander.conversions import pose_to_list
 
 def all_close(goal, actual, tolerance):
   """
-  Convenience method for testing if a list of values are within a tolerance of their counterparts in another list
+  Convenience method for testing if the values in two lists are within a tolerance of each other.
+  For Pose and PoseStamped inputs, the angle between the two quaternions is compared (the angle 
+  between the identical orientations q and -q is calculated correctly).
   @param: goal       A list of floats, a Pose or a PoseStamped
   @param: actual     A list of floats, a Pose or a PoseStamped
   @param: tolerance  A float

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -51,7 +51,7 @@ import rospy
 import moveit_commander
 import moveit_msgs.msg
 import geometry_msgs.msg
-from math import pi
+from math import pi, dist, fabs, cos
 from std_msgs.msg import String
 from moveit_commander.conversions import pose_to_list
 ## END_SUB_TUTORIAL
@@ -75,7 +75,13 @@ def all_close(goal, actual, tolerance):
     return all_close(goal.pose, actual.pose, tolerance)
 
   elif type(goal) is geometry_msgs.msg.Pose:
-    return all_close(pose_to_list(goal), pose_to_list(actual), tolerance)
+    x0, y0, z0, qx0, qy0, qz0, qw0 = pose_to_list(actual)
+    x1, y1, z1, qx1, qy1, qz1, qw1 = pose_to_list(goal)
+    # Euclidian distance
+    d = dist((x1, y1, z1), (x0, y0, z0))
+    # phi = angle between orientations
+    cos_phi_half = fabs(qx0*qx1 + qy0*qy1 + qz0*qz1 + qw0*qw1)
+    return d <= tolerance and cos_phi_half >= cos(tolerance / 2.0)
 
   return True
 


### PR DESCRIPTION
test:
```
import numpy as np
from scipy.spatial.transform import Rotation as R
from moveit_commander.conversions import list_to_pose

for i in range(10000):
  rot0 = R.random()
  axis = np.random.rand(3)
  axis = axis / np.linalg.norm(axis)
  angle = 0.01

  rot1 = rot0 * R.from_rotvec(axis * angle)

  assert all_close(
    list_to_pose([0,0,0] + list(R.as_quat(rot0))),
    list_to_pose([0,0,0] + list(R.as_quat(rot1))),
    angle + 1e-8
  )

  assert not all_close(
    list_to_pose([0,0,0] + list(R.as_quat(rot0))),
    list_to_pose([0,0,0] + list(R.as_quat(rot1))),
    angle - 1e-8
  )

  # check with negative quaternion
  assert all_close(
    list_to_pose([0,0,0] + list(R.as_quat(rot0))),
    list_to_pose([0,0,0] + list(-R.as_quat(rot1))),
    angle + 1e-8
  )

  assert not all_close(
    list_to_pose([0,0,0] + list(R.as_quat(rot0))),
    list_to_pose([0,0,0] + list(-R.as_quat(rot1))),
    angle - 1e-8
  )
```

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
