### PR TITLE
Set Bullet as the exclusive collision detection algorithm.

### DIFF
--- a/doc/bullet_collision_checker/src/bullet_collision_checker_tutorial.cpp
+++ b/doc/bullet_collision_checker/src/bullet_collision_checker_tutorial.cpp
@@ -211,7 +211,7 @@ int main(int argc, char** argv)
   // again set as the active collision detector.
   robot_model::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("panda");
   auto planning_scene = std::make_shared<planning_scene::PlanningScene>(robot_model);
-  planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(), true /* exclusive */);
+  planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(), /* exclusive = */ true);
 
   // The box is added and the robot brought into its position.
   Eigen::Isometry3d box_pose{ Eigen::Isometry3d::Identity() };

--- a/doc/bullet_collision_checker/src/bullet_collision_checker_tutorial.cpp
+++ b/doc/bullet_collision_checker/src/bullet_collision_checker_tutorial.cpp
@@ -166,7 +166,8 @@ int main(int argc, char** argv)
     // Bullet. The second argument indicates that Bullet will be the exclusive collision detection algorithm; the
     // default FCL will not be available anymore. Having one exclusive collision detection algorithm helps performance
     // a bit and is much more common.
-    g_planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(), true /* exclusive */);
+    g_planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(),
+                                                 true /* exclusive */);
     // For understanding the interactive interactive_robot, please refer to the Visualizing Collisions tutorial.
     // CALL_SUB_TUTORIAL CCD
     // CALL_SUB_TUTORIAL CCD_2
@@ -211,7 +212,8 @@ int main(int argc, char** argv)
   // again set as the active collision detector.
   robot_model::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("panda");
   auto planning_scene = std::make_shared<planning_scene::PlanningScene>(robot_model);
-  planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(), /* exclusive = */ true);
+  planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(),
+                                             /* exclusive = */ true);
 
   // The box is added and the robot brought into its position.
   Eigen::Isometry3d box_pose{ Eigen::Isometry3d::Identity() };

--- a/doc/bullet_collision_checker/src/bullet_collision_checker_tutorial.cpp
+++ b/doc/bullet_collision_checker/src/bullet_collision_checker_tutorial.cpp
@@ -163,8 +163,10 @@ int main(int argc, char** argv)
     // Changing the collision detector to Bullet
     // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     // The active collision detector is set from the planning scene using the specific collision detector allocator for
-    // Bullet.
-    g_planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create());
+    // Bullet. The second argument indicates that Bullet will be the exclusive collision detection algorithm; the
+    // default FCL will not be available anymore. Having one exclusive collision detection algorithm helps performance
+    // a bit and is much more common.
+    g_planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(), true /* exclusive */);
     // For understanding the interactive interactive_robot, please refer to the Visualizing Collisions tutorial.
     // CALL_SUB_TUTORIAL CCD
     // CALL_SUB_TUTORIAL CCD_2
@@ -209,7 +211,7 @@ int main(int argc, char** argv)
   // again set as the active collision detector.
   robot_model::RobotModelPtr robot_model = moveit::core::loadTestingRobotModel("panda");
   auto planning_scene = std::make_shared<planning_scene::PlanningScene>(robot_model);
-  planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create());
+  planning_scene->setActiveCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create(), true /* exclusive */);
 
   // The box is added and the robot brought into its position.
   Eigen::Isometry3d box_pose{ Eigen::Isometry3d::Identity() };


### PR DESCRIPTION
This sets Bullet as the **exclusive** collision detection algorithm and adds a comment. I believe it's not well-known that MoveIt was designed to maintain a list of collision detection algorithms and switch between them at runtime. However, this is an advanced feature that is not well-tested and I already found one [bug](https://github.com/ros-planning/moveit/pull/2497). So I don't think we should be recommending it to the world.

The documentation on this **exclusive** arg is [here](http://docs.ros.org/en/noetic/api/moveit_core/html/classplanning__scene_1_1PlanningScene.html#ac2e8c853ad8af28a2632ae8c79f4bd83).