### PR TITLE
typos corrected and support added for getting_started

### DIFF
--- a/_scripts/tutorialformatter.py
+++ b/_scripts/tutorialformatter.py
@@ -118,7 +118,7 @@ class TutorialFormatterDirective(rst.Directive):
                 if sub_name in subs:
                     flattened_lines.extend( subs[sub_name] )
                 else:
-                    print 'tutorialformatter.py error: sub-tutorial %s not found.' % sub_name
+                    print ('tutorialformatter.py error: sub-tutorial %s not found.' % sub_name)
             else:
                 flattened_lines.append( line )
         return flattened_lines
@@ -144,7 +144,7 @@ class TutorialFormatterDirective(rst.Directive):
         code_prefix = '\n.. code-block:: ' + language + '\n\n'
         code_suffix = '\n'
 
-        print "tutorial-formatter running on", absfilename
+        print ("tutorial-formatter running on", absfilename)
         file_ = open( absfilename, 'r' )
         text_to_process = ""
         current_block = ""

--- a/_scripts/tutorialformatter.py
+++ b/_scripts/tutorialformatter.py
@@ -118,7 +118,7 @@ class TutorialFormatterDirective(rst.Directive):
                 if sub_name in subs:
                     flattened_lines.extend( subs[sub_name] )
                 else:
-                    print ('tutorialformatter.py error: sub-tutorial %s not found.' % sub_name)
+                    print("tutorialformatter.py error: sub-tutorial " + sub_name + " not found.")
             else:
                 flattened_lines.append( line )
         return flattened_lines
@@ -144,7 +144,7 @@ class TutorialFormatterDirective(rst.Directive):
         code_prefix = '\n.. code-block:: ' + language + '\n\n'
         code_suffix = '\n'
 
-        print ("tutorial-formatter running on", absfilename)
+        print("tutorial-formatter running on", absfilename)
         file_ = open( absfilename, 'r' )
         text_to_process = ""
         current_block = ""

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -23,22 +23,7 @@ The simplest way to install MoveIt is from pre-built binaries (Debian): ::
   sudo apt install ros-melodic-moveit
 
 Advanced users might want to `install MoveIt from source <http://moveit.ros.org/install/source/>`_.
-If you clone your own moveit fork into the workspace, disable the moveit repository in the .rosinstall file.
-You could clone your forked moveit repositories into the workspace using wstool as described in `install MoveIt from source <http://moveit.ros.org/install/source/>`_ by editing the contents of the .rosinstall file.
-Let's say you wanted to clone your forked 'moveit' repo, you could do it by the following changes in the .rosinstall file of your forked repository: ::
-
-    local-name: moveit
-    uri: https://github.com/ros-planning/moveit.git
-
-to: ::
-
-    local-name: moveit
-    uri: https://github.com/your-github-username/moveit.git
-
-and finally use your forked repository name in the wstool merge command as given in the tutorial: ::
-
-    wstool merge -t src https://raw.githubusercontent.com/your-github-username/moveit/master/moveit.rosinstall
-
+If you want to build your own MoveIt fork, replace the repository uri in the .rosinstall file with your own.
 
 Create A Catkin Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -23,6 +23,22 @@ The simplest way to install MoveIt is from pre-built binaries (Debian): ::
   sudo apt install ros-melodic-moveit
 
 Advanced users might want to `install MoveIt from source <http://moveit.ros.org/install/source/>`_.
+If you clone your own moveit fork into the workspace, disable the moveit repository in the .rosinstall file.
+You could clone your forked moveit repositories into the workspace using wstool as described in `install MoveIt from source <http://moveit.ros.org/install/source/>`_ by editing the contents of the .rosinstall file.
+Let's say you wanted to clone your forked 'moveit' repo, you could do it by the following changes in the .rosinstall file of your forked repository: ::
+
+    local-name: moveit
+    uri: https://github.com/ros-planning/moveit.git
+
+to: ::
+
+    local-name: moveit
+    uri: https://github.com/your-github-username/moveit.git
+
+and finally use your forked repository name in the wstool merge command as given in the tutorial: ::
+
+    wstool merge -t src https://raw.githubusercontent.com/your-github-username/moveit/master/moveit.rosinstall
+
 
 Create A Catkin Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Due to some typos in _scripts/tutorialformatter.py, ./build_locally.sh was not running, corrected them.

If any user wanted to build 'moveit' from source using his/her forked repository (for later contribution), it gets a little confusing as the 'build from source' tutorial mentions cloning (with wstool) using the ros_planning/moveit repos only. Support added for how he/she can clone the forked repository following the same lines as the provided tutorial (wstool) by changing few lines in the .rosinstall files.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
