### PR TITLE
update banner for moveit2 - foxy

### DIFF
--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,5 +1,7 @@
 <br />
 <div class="admonition note">
-<p class="first admonition-title">Tutorials Version: Melodic</p>
-<p class="last">This is the latest release version, Melodic, which is LTS-stable. For advanced developers, we recommmend the latest <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">master branch tutorials</a>. Kinetic users, please use the <a class="reference external" href="http://docs.ros.org/kinetic/api/moveit_tutorials/html/index.html">Kinetic tutorials.</a></p>
+<p class="first admonition-title">WARNING: Old Tutorial Version</p>
+<p class="last">These tutorials are for an old version of Moveit! <br/>
+    The latest version of MoveIt is <a href="http://moveit2_tutorials.picknik.ai/">MoveIt2 - Foxy (ROS2)</a>. <br/>
+    For ROS1/MoveIt1 Tutorials, the latest version is <a class="reference external" href="https://ros-planning.github.io/moveit_tutorials/">MoveIt1 - Noetic</a>.</p>
 </div>


### PR DESCRIPTION
### Description

Update the warning banner to point to MoveIt2 Foxy and MoveIt1 Noetic

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
