### PR TITLE
Fix rosdoc-lite to autoinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,13 @@ This repository is currently built automatically by two systems. Travis builds t
 
 ## Build Locally
 
-If you want to test the tutorials by generating the html pages locally on your machine, you will first need to install the `rosdoc_lite` package, and then you can use the ``build_locally`` script.
+If you want to test the tutorials by generating the html pages locally on your machine, you can use the ``build_locally`` script.
 Run in the root of the moveit_tutorials package:
-
-> **_NOTE:_**  [rosdoc_lite](https://wiki.ros.org/rosdoc_lite) is needed to run the build_locally.sh script!
 
     export ROS_DISTRO=kinetic # 16.04
     export ROS_DISTRO=melodic # 18.04
     export ROS_DISTRO=noetic  # 20.04
 
-    sudo apt install ros-$ROS_DISTRO-rosdoc-lite
     source /opt/ros/$ROS_DISTRO/setup.bash
     ./build_locally.sh
 

--- a/build_locally.sh
+++ b/build_locally.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 # Install rosdoc_lite if it isn't there yet
-test -x `which rosdoc_lite` || sudo apt install ros-$ROS_DISTRO-rosdoc-lite
+if ! command -v rosdoc_lite &> /dev/null
+then
+  echo "Installing rosdoc_lite"
+  sudo apt install ros-$ROS_DISTRO-rosdoc-lite
+fi
 
 # Setup Environment
 rm -rf build


### PR DESCRIPTION
This shouldn't need to be manually installed.