### PR TITLE
Add planning pipeline and planner id to move_group_interface tutorial

### DIFF
--- a/doc/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -115,6 +115,9 @@ int main(int argc, char** argv)
   ROS_INFO_NAMED("tutorial", "Available Planning Groups:");
   std::copy(move_group_interface.getJointModelGroupNames().begin(),
             move_group_interface.getJointModelGroupNames().end(), std::ostream_iterator<std::string>(std::cout, ", "));
+  
+  // We can get the planning pipeline that is set (OMPL by default):
+  ROS_INFO_NAMED("tutorial", "Current pipeline: %s", move_group_interface.getPlanningPipelineId().c_str());
 
   // Start the demo
   // ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,17 +155,28 @@ int main(int argc, char** argv)
   visual_tools.trigger();
   visual_tools.prompt("Press 'next' in the RvizVisualToolsGui window to continue the demo");
 
-  // Finally, to execute the trajectory stored in my_plan, you could use the following method call:
+  // To execute the trajectory stored in my_plan, you can use the following method call:
   // Note that this can lead to problems if the robot moved in the meanwhile.
   // move_group_interface.execute(my_plan);
+
+  // You can also use a different planning pipeline (OMPL by default), such as the Pilz
+  // industrial motion planner:
+  // move_group_interface.setPlanningPipelineId("pilz_industrial_motion_planner");
+  // move_group_interface.setPlannerId("LIN");
+
+  // Or, to plan only one motion with a different planner:
+
+  success = (move_group_interface.plan(my_plan, "pilz_industrial_motion_planner", "LIN") == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  visual_tools.publishTrajectoryLine(my_plan.trajectory_, joint_model_group);
+  visual_tools.trigger();
+  visual_tools.prompt("Press 'next' in the RvizVisualToolsGui window to continue the demo");
 
   // Moving to a pose goal
   // ^^^^^^^^^^^^^^^^^^^^^
   //
-  // If you do not want to inspect the planned trajectory,
-  // the following is a more robust combination of the two-step plan+execute pattern shown above
-  // and should be preferred. Note that the pose goal we had set earlier is still active,
-  // so the robot will try to move to that goal.
+  // If you do not want to inspect the planned trajectory, you can call the "move"
+  // command to combine the plan+execute pattern shown above. Note that the pose goal 
+  // we set earlier is still active, so the robot will try to move to that goal.
 
   // move_group_interface.move();
 

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -255,7 +255,7 @@ class MoveGroupPythonInterfaceTutorial(object):
     ## Cartesian Paths
     ## ^^^^^^^^^^^^^^^
     ## You can plan a Cartesian path directly by specifying a list of waypoints
-    ## for the end-effector to go through. If executing  interactively in a
+    ## for the end-effector to go through. If executing interactively in a
     ## Python shell, set scale = 1.0.
     ##
     waypoints = []
@@ -309,7 +309,7 @@ class MoveGroupPythonInterfaceTutorial(object):
     display_trajectory.trajectory_start = robot.get_current_state()
     display_trajectory.trajectory.append(plan)
     # Publish
-    display_trajectory_publisher.publish(display_trajectory);
+    display_trajectory_publisher.publish(display_trajectory)
 
     ## END_SUB_TUTORIAL
 

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -178,12 +178,12 @@ class MoveGroupPythonInterfaceTutorial(object):
     ## We use the constant `tau = 2*pi <https://en.wikipedia.org/wiki/Turn_(angle)#Tau_proposals>`_ for convenience:
     # We get the joint values from the group and change some of the values:
     joint_goal = move_group.get_current_joint_values()
-    joint_goal[0] = 0
-    joint_goal[1] = -tau/8
-    joint_goal[2] = 0
-    joint_goal[3] = -tau/4
-    joint_goal[4] = 0
-    joint_goal[5] = tau/6  # 1/6 of a turn
+    joint_goal[0] = -tau/8
+    joint_goal[1] = -tau/6
+    joint_goal[2] = tau/6  # 1/6 of a turn
+    joint_goal[3] = -tau/3
+    joint_goal[4] = -tau/12
+    joint_goal[5] = tau/4
     joint_goal[6] = 0
 
     # The go command can be called with joint values, poses, or without any
@@ -220,8 +220,15 @@ class MoveGroupPythonInterfaceTutorial(object):
 
     move_group.set_pose_target(pose_goal)
 
-    ## Now, we call the planner to compute the plan and execute it.
-    plan = move_group.go(wait=True)
+    ## We call the planner to compute the plan and execute it.
+    plan = move_group.plan()
+    # "move_group.execute(plan, wait=True)" would execute the plan
+
+    ## We can also specify a planner directly. The default planning pipeline in Moveit is OMPL. 
+    ## The Pilz Industrial Motion planner offers PTP, LIN and CIRC motions. 
+    ## See `the Pilz tutorial <../pilz_industrial_motion_planner/pilz_industrial_motion_planner.html>`_ for details.
+    plan = move_group.go(wait=True, planning_pipeline="pilz_industrial_motion_planner", planner_id="LIN")
+    
     # Calling `stop()` ensures that there is no residual movement
     move_group.stop()
     # It is always good to clear your targets after planning with poses.


### PR DESCRIPTION
This adds examples for setting a different planner in the `MoveGroupInterface` tutorials. Depends on another PR I will link to.

I changed the joint pose in the Python tutorial so that both PTP and LIN would succeed.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
