### PR TITLE
Add Python2 compatibility

### DIFF
--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -51,12 +51,13 @@ import rospy
 import moveit_commander
 import moveit_msgs.msg
 import geometry_msgs.msg
-from math import pi, dist, fabs, cos
 try:
-  from math import tau
+  from math import pi, tau, dist, fabs, cos
 except: # For Python 2 compatibility
-  from math import pi
+  from math import pi, fabs, cos, sqrt
   tau = 2.0*pi
+  def dist(p, q):
+    return sqrt(sum((p_i - q_i)**2.0 for p_i, q_i in zip(p,q)))
 from std_msgs.msg import String
 from moveit_commander.conversions import pose_to_list
 ## END_SUB_TUTORIAL


### PR DESCRIPTION
Our move_group Python Interface tutorial uses some Python3-exclusive functions, but our master branch builds on Kinetic and Melodic, where Python2 is the standard. These changes allow running the tutorial in Python 2.7.

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
