### PR TITLE
Add rviz build dependency to correctly set linker paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED
     moveit_ros_planning
     moveit_ros_planning_interface
     moveit_ros_perception
+    rviz
     rviz_visual_tools
     moveit_visual_tools
     pluginlib

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
   <build_depend>interactive_markers</build_depend>
   <build_depend>geometric_shapes</build_depend>
   <build_depend>moveit_visual_tools</build_depend>
+  <build_depend>rviz</build_depend>
   <build_depend>rviz_visual_tools</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_conversions</build_depend>


### PR DESCRIPTION
### Description

This seems to fix linking against librviz_default_plugin.so from system packages (melodic) when I actually have a newer version (noetic-devel) in my workspace
