### PR TITLE
added note on how to run ``rosdep install`` on Ubuntu based distros

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -54,6 +54,8 @@ The following will install from Debian any package dependencies not already in y
   cd ~/ws_moveit/src
   rosdep install -y --from-paths . --ignore-src --rosdistro noetic
 
+**Note** In case you're using an Ubuntu based distribution your can specifiy the Ubuntu base of your distro using ``--os ubuntu:base`` for example in Case of Mint 20.1 which is based on Ubuntu focal use ``--os ubuntu:focal``
+
 **Note** In case an upstream package is not (yet) available from the standard ROS repositories or if you experience any build errors in those packages, please try to fetch the latest release candidates from the `ROS testing repositories <http://wiki.ros.org/TestingRepository>`_ instead: ::
 
         sudo sh -c 'echo "deb http://packages.ros.org/ros-testing/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'


### PR DESCRIPTION
added note on how to run ``rosdep install`` on Ubuntu based distros

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
