### PR TITLE
Fix broken links in constraint tutorial

### DIFF
--- a/doc/planning_constraints/planning_constraints.rst
+++ b/doc/planning_constraints/planning_constraints.rst
@@ -23,4 +23,4 @@ A related functionality to representing and evaluating constraints is :code:`con
 See Also
 --------
 - `How to plan with path constraints in general <../move_group_interface/move_group_interface_tutorial.html#planning-with-path-constraints>`_.
-- `Planning with Approximated Constraint Manifolds <../planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial>`_.
+- `Planning with Approximated Constraint Manifolds <../planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.html>`_.

--- a/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
+++ b/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.rst
@@ -3,7 +3,7 @@ Planning with Approximated Constraint Manifolds
 
 OMPL supports custom constraints to enable planning trajectories that follow a desired behavior.
 Constraints can be defined in joint space and Cartesian space where the latter is either orientation or position based.
-While planning a trajectory, each joint state needs to follow all of the set constraints, which is performed by rejection sampling by default. For more information see `Representation and Evaluation of Constraints <../planning_constraints/planning_constraints>`_.
+While planning a trajectory, each joint state needs to follow all of the set constraints, which is performed by rejection sampling by default. For more information see `Representation and Evaluation of Constraints <../planning_constraints/planning_constraints.html>`_.
 
 Rejection sampling for each joint state might lead to very long planning times, especially when the constraints are very restrictive and the rejection rate is correspondingly high. `Sucan et al <http://ioan.sucan.ro/files/pubs/constraints_iros2012.pdf>`_ present an approach where they compute an approximation of the constraint manifold beforehand and perform trajectory planning in that.
 The OMPL plugin contains the functionality to do that for a given set of constraints and save it in a database.


### PR DESCRIPTION
I thought CI was failing only because were were creating an new page, but actually the URLs were incorrect.