### PR TITLE
fix iss470

### DIFF
--- a/doc/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch
+++ b/doc/motion_planning_pipeline/launch/motion_planning_pipeline_tutorial.launch
@@ -10,13 +10,24 @@
     <arg name="load_robot_description" value="true"/>
   </include>
 
-  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 world panda_link0" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="true"/>
+    <param name="/use_gui" value="false"/>
+    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
   </node>
 
+  <node name="joint_state_desired_publisher" pkg="topic_tools" type="relay" args="joint_states joint_states_desired" />
+
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+  <include file="$(find panda_moveit_config)/launch/move_group.launch">
+    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="fake_execution" value="true"/>
+    <arg name="info" value="true"/>
+    <arg name="debug" value="$(arg debug)"/>
+    <arg name="pipeline" value="ompl"  />
+  </include>
 
   <include file="$(find panda_moveit_config)/launch/moveit_rviz.launch">
   </include>

--- a/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -66,12 +66,14 @@ int main(int argc, char** argv)
   //     http://docs.ros.org/melodic/api/moveit_ros_planning/html/classrobot__model__loader_1_1RobotModelLoader.html
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
   robot_model::RobotModelPtr robot_model = robot_model_loader.getModel();
+  robot_state::RobotState robot_state(robot_model);
+  const robot_state::JointModelGroup* joint_model_group = robot_state.getJointModelGroup("panda_arm");
 
   // Using the :moveit_core:`RobotModel`, we can construct a
   // :planning_scene:`PlanningScene` that maintains the state of
   // the world (including the robot).
   planning_scene::PlanningScenePtr planning_scene(new planning_scene::PlanningScene(robot_model));
-
+  planning_scene->getCurrentStateNonConst().setToDefaultValues(joint_model_group, "ready");
   // We can now setup the PlanningPipeline
   // object, which will use the ROS parameter server
   // to determine the set of request adapters and the
@@ -166,9 +168,7 @@ int main(int argc, char** argv)
   // Joint Space Goals
   // ^^^^^^^^^^^^^^^^^
   /* First, set the state in the planning scene to the final state of the last plan */
-  robot_state::RobotState& robot_state = planning_scene->getCurrentStateNonConst();
   planning_scene->setCurrentState(response.trajectory_start);
-  const robot_model::JointModelGroup* joint_model_group = robot_state.getJointModelGroup("panda_arm");
   robot_state.setJointGroupPositions(joint_model_group, response.trajectory.joint_trajectory.points.back().positions);
 
   // Now, setup a joint space goal


### PR DESCRIPTION
### Description
Fixes Issue: #470 

Issue:
1. Robot loads in an invalid state.
2. Error stating unable to plan goal

Changes made:
_motion_planning_pipeline_tutorial.cpp:_
1. Set Robot State to `ready` state. (previously in collision)
    `planning_scene->getCurrentStateNonConst().setToDefaultValues(joint_model_group, "ready");`
2. Remove re-declarations of `robot_state` and `joint_model_group`.

_motion_planning_pipeline_tutorial.launch:_
1. Fix `virtual_joint_broadcaster_0` args
2. Add `/source_list` param to `joint_state_publisher` 
3. Include `move_group.launch`
4. Add a `relay` node to remap `/joint_states` to `/joint_states_desired` (later topic required by `move_group` node)

How changes fix the issue:
Setting the robot to `ready` state brings the joint configurations to a valid state. Though this fixes the state and planning issue, this still does not fix the visual of robot in RViz as moveit is not subscribing to `/joint_states`. The changes in launch file fixes this issue.
