### PR TITLE
Clone moveit_task_constructor repo since .rosinstall file was deleted

### DIFF
--- a/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
+++ b/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
@@ -22,7 +22,7 @@ Install From Source
 Go into your catkin workspace and initialize wstool if necessary (assuming `~/ws_moveit` as workspace path): ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/ros-planning/moveit_task_constructor.git -b master
+  git clone https://github.com/ros-planning/moveit_task_constructor.git
 
 Install missing packages with rosdep: ::
 

--- a/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
+++ b/doc/moveit_task_constructor/moveit_task_constructor_tutorial.rst
@@ -22,12 +22,7 @@ Install From Source
 Go into your catkin workspace and initialize wstool if necessary (assuming `~/ws_moveit` as workspace path): ::
 
   cd ~/ws_moveit/src
-  wstool init
-
-Clone MoveIt Task Constructor and source dependencies: ::
-
-  wstool merge https://raw.githubusercontent.com/ros-planning/moveit_task_constructor/master/.rosinstall
-  wstool update
+  git clone https://github.com/ros-planning/moveit_task_constructor.git -b master
 
 Install missing packages with rosdep: ::
 


### PR DESCRIPTION
### Description

Fix: https://github.com/ros-planning/moveit_task_constructor/issues/269

`.rosinstall` file was deleted in this [commit](https://github.com/ros-planning/moveit_task_constructor/commit/cc5f1ad93439929ba6c30ccccf41f93c12e8595d) so we just clone the repo directly

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
