### PR TITLE
Remove redundant install instructions

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -39,7 +39,7 @@ Download Example Code
 
 To easily follow along with these tutorials, you will need a **ROBOT_moveit_config** package. The default demo robot is the Panda arm from Franka Emika. To get a working **panda_moveit_config** package, we recommend you install from source.
 
-Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download the tutorials as well as the ``panda_moveit_config`` package: ::
+Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download the tutorials as well as the ``panda_moveit_config`` package. You may safely ignore any :code:`git clone` errors saying the destination already exists: ::
 
   cd ~/ws_moveit/src
   git clone https://github.com/ros-planning/moveit_tutorials.git -b master


### PR DESCRIPTION
### Description

For the Noetic tutorials, I noticed the Getting Started page had you

1. Install MoveIt from source
2. Remove `moveit_tutorials`
3. Add `moveit_tutorials`
4. Add `panda_moveit_config` (which already came with the rosinstall, git complains if run following the instructions)

This PR just removed steps 2-4, and modified the note about the moveit config package

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
