### PR TITLE
Enable CI on PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,7 @@ name: Build+Test+Deploy
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
I realized previously merged PR #634 only builds the pages on pushes. We would want to build the pages but not deploy it in PRs. This PR enables building pages in PRs without deploying it.