### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -65,6 +65,15 @@ The next command will configure your catkin workspace: ::
   catkin config --extend /opt/ros/${ROS_DISTRO} --cmake-args -DCMAKE_BUILD_TYPE=Release
   catkin build
 
+**Note** If catkin config gives you this error: 
+
+  pkg_resources.DistributionNotFound: The 'osrf-pycommon>0.1.1' distribution was not found and is required by catkin-tools
+
+then install osrf-pycommon manually:
+
+  sudo apt install python3-catkin-lint python3-pip
+  pip3 install osrf-pycommon
+
 Source the catkin workspace: ::
 
   source ~/ws_moveit/devel/setup.bash


### PR DESCRIPTION
fresh install ran into the problem myself and found the solution burried here: https://github.com/catkin/catkin_tools/issues/594

### Description

There is a problem with the tutorial not installing the correct osrf-pycommon. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
