### PR TITLE
Augment python3-osrf-pycommon dependency

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -16,7 +16,7 @@ Once you have ROS installed, make sure you have the most up to date packages: ::
 
 Install `catkin <http://wiki.ros.org/catkin>`_ the ROS build system: ::
 
-  sudo apt install ros-noetic-catkin python3-catkin-tools
+  sudo apt install ros-noetic-catkin python3-catkin-tools python3-osrf-pycommon
 
 Install `wstool <http://wiki.ros.org/wstool>`_ : ::
 


### PR DESCRIPTION
python3-osrf-pycommon is required in addition to python3-catkin-tools due to a wrongly configured Debian dependency
(see https://github.com/catkin/catkin_tools/issues/594).

Fixes #652