### PR TITLE
Motion planning pipeline duplicate comments fix

### DIFF
--- a/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -76,11 +76,10 @@ int main(int argc, char** argv)
   planning_scene_monitor::PlanningSceneMonitorPtr psm(
       new planning_scene_monitor::PlanningSceneMonitor(robot_model_loader));
 
-  /* listen for planning scene messages on topic /XXX and apply them to the internal planning scene
+  /* listen for planning scene messages on topic /XXX and apply them to
                        the internal planning scene accordingly */
   psm->startSceneMonitor();
-  /* listens to changes of world geometry, collision objects, and (optionally) octomaps
-                                world geometry, collision objects and optionally octomaps */
+  /* listens to changes of world geometry, collision objects, and (optionally) octomaps */
   psm->startWorldGeometryMonitor();
   /* listen to joint state updates as well as changes in attached collision objects
                         and update the internal planning scene accordingly*/


### PR DESCRIPTION
### Description

Deleted some duplicate comments on the motion planning pipeline tutorial file

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
