### PR TITLE
Don't use deprecated panda_arm_hand Xacro

### DIFF
--- a/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
+++ b/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- load URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm.urdf.xacro' hand:=true"/>
 
   <!-- load SRDF -->
   <param name="robot_description_semantic" command="$(find xacro)/xacro --inorder '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'"/>


### PR DESCRIPTION
### Description

This PR remove the usage of `panda_arm_hand.urdf.xacro` (which is deprecated) and replaced by `panda_arm.urdf.xacro hand:=true`.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
