### PR TITLE
Fixes panda_moveit_config branch in 'getting started'

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -43,7 +43,7 @@ Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download the tutor
 
   cd ~/ws_moveit/src
   git clone https://github.com/ros-planning/moveit_tutorials.git -b master
-  git clone https://github.com/ros-planning/panda_moveit_config.git -b melodic-devel
+  git clone https://github.com/ros-planning/panda_moveit_config.git -b noetic-devel
 
 .. note:: For now we will use a pre-generated ``panda_moveit_config`` package but later we will learn how to make our own in the `MoveIt Setup Assistant tutorial <../setup_assistant/setup_assistant_tutorial.html>`_.
 


### PR DESCRIPTION
### Description

This pull request changes the [panda_moveit_config](https://github.com/ros-planning/panda_moveit_config/tree/noetic-devel) branch to the new `noetic-devel` branch in the [getting_started](https://ros-planning.github.io/moveit_tutorials/doc/getting_started/getting_started.html) tutorial.