### PR TITLE
Remove Kinetic From Dropdown menu

### DIFF
--- a/_themes/sphinx_rtd_theme/version_dropdown.html
+++ b/_themes/sphinx_rtd_theme/version_dropdown.html
@@ -5,7 +5,6 @@
         <option value="http://moveit2_tutorials.picknik.ai">Moveit 2 - Foxy</option>
         <option value='' selected>MoveIt 1 - {{ version }}</option>
         <option value="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">MoveIt 1 - Melodic</option>
-        <option value="http://docs.ros.org/en/kinetic/api/moveit_tutorials/html/index.html">MoveIt 1 - Kinetic</option>
     </select>
     </div>
 </div><br>


### PR DESCRIPTION
### Description

Remove Kinetic from the dropdown menu. This needs to be done for Noetic & Foxy as well.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
