### PR TITLE
Update link to Foxy

### DIFF
--- a/_themes/sphinx_rtd_theme/moveit_version.html
+++ b/_themes/sphinx_rtd_theme/moveit_version.html
@@ -1,6 +1,6 @@
 <br />
 <div class="admonition note">
 <p class="first admonition-title">Tutorials Version: Noetic</p>
-<p class="last">This is the latest (and last) version of MoveIt 1 for ROS Noetic, which is still actively developed. See also <a class="reference external" href="http://moveit2_tutorials.picknik.ai/">MoveIt 2 tutorials</a> and other available versions in drop down box on left.
+<p class="last">This is the latest (and last) version of MoveIt 1 for ROS Noetic, which is still actively developed. See also <a class="reference external" href="https://moveit.picknik.ai/">MoveIt 2 tutorials</a> and other available versions in drop down box on left.
 </p>
 </div>

--- a/_themes/sphinx_rtd_theme/version_dropdown.html
+++ b/_themes/sphinx_rtd_theme/version_dropdown.html
@@ -2,7 +2,7 @@
     <div class="version-dropdown">
         <lable for="version-list">Version:</lable>
     <select class="version-list" id="version-list" onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
-        <option value="http://moveit2_tutorials.picknik.ai">Moveit 2 - Foxy</option>
+        <option value="http://moveit.picknik.ai">Moveit 2 - Foxy</option>
         <option value='' selected>MoveIt 1 - {{ version }}</option>
         <option value="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">MoveIt 1 - Melodic</option>
     </select>

--- a/_themes/sphinx_rtd_theme/version_dropdown.html
+++ b/_themes/sphinx_rtd_theme/version_dropdown.html
@@ -2,7 +2,7 @@
     <div class="version-dropdown">
         <lable for="version-list">Version:</lable>
     <select class="version-list" id="version-list" onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
-        <option value="http://moveit.picknik.ai">Moveit 2 - Foxy</option>
+        <option value="https://moveit.picknik.ai">Moveit 2 - Foxy</option>
         <option value='' selected>MoveIt 1 - {{ version }}</option>
         <option value="http://docs.ros.org/en/melodic/api/moveit_tutorials/html/index.html">MoveIt 1 - Melodic</option>
     </select>


### PR DESCRIPTION
### Description

This updates the links to the moveit2 tutorials website to be moveit.picknik.ai instead of moveit2_tutorials.picknik.ai.  The reason for this change is URLs with _ in them don't get a SSL cert from github :(

