### PR TITLE
Update trac_ik installation for ROS Noetic

### DIFF
--- a/doc/trac_ik/trac_ik_tutorial.rst
+++ b/doc/trac_ik/trac_ik_tutorial.rst
@@ -10,11 +10,9 @@ The package `trac_ik_kinematics_plugin <https://bitbucket.org/traclabs/trac_ik/s
 Install
 -------
 
-As of v1.5.1, **trac_ik** is part of the ROS Kinetic/Melodic binaries: ::
+To install **trac_ik** for ROS Noetic, use the following command: ::
 
-  sudo apt-get install ros-melodic-trac-ik-kinematics-plugin
-
-Binaries for Noetic are not yet available. You can track the progress `with this ticket <https://bitbucket.org/traclabs/trac_ik/issues/67/ros-noetic-support>`_.
+  sudo apt-get install ros-noetic-trac-ik-kinematics-plugin
 
 Usage
 -----


### PR DESCRIPTION
### Description

trac_ik is now available for ROS Noetic, so updated its installation instructions to the noetic version.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
