### PR TITLE
urdf file name corrected to avoid launch errors

### DIFF
--- a/doc/bullet_collision_checker/launch/bullet_collision_checker_tutorial.launch
+++ b/doc/bullet_collision_checker/launch/bullet_collision_checker_tutorial.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- load URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro hand:=true'" />
 
   <!-- load SRDF -->
   <param name="robot_description_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'" />

--- a/doc/bullet_collision_checker/launch/bullet_collision_checker_tutorial.launch
+++ b/doc/bullet_collision_checker/launch/bullet_collision_checker_tutorial.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- load URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm.urdf.xacro'" />
 
   <!-- load SRDF -->
   <param name="robot_description_semantic" command="$(find xacro)/xacro --inorder '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'"/>

--- a/doc/bullet_collision_checker/launch/bullet_collision_checker_tutorial.launch
+++ b/doc/bullet_collision_checker/launch/bullet_collision_checker_tutorial.launch
@@ -1,10 +1,10 @@
 <launch>
 
   <!-- load URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find franka_description)/robots/panda_arm.urdf.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'" />
 
   <!-- load SRDF -->
-  <param name="robot_description_semantic" command="$(find xacro)/xacro --inorder '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'"/>
+  <param name="robot_description_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'" />
 
   <!-- Run RViz with a custom config -->
   <node name="$(anon rviz)" pkg="rviz" type="rviz" respawn="false" args="-d $(find moveit_tutorials)/doc/bullet_collision_checker/launch/moveit.rviz" output="screen">

--- a/doc/gazebo_simulation/gazebo_simulation.rst
+++ b/doc/gazebo_simulation/gazebo_simulation.rst
@@ -27,14 +27,14 @@ the procedure outlined in there will be repeated (with improvements) in here as 
 
 1. Fix the robot to the world coordinate system
 -----------------------------------------------
-Open the :code:`franka_description/robots/panda_arm_hand.urdf.xacro` file and change the line 5 with:
+Open the :code:`franka_description/robots/panda_arm.urdf.xacro` file and change the line 5 with:
 
 .. code-block:: xml
 
     <xacro:panda_arm xyz="0 0 0" rpy="0 0 0" connected_to="world"/>
 
 It alone doesn't fix the problem, since now we need to provide a link with name :code:`world`. Add the following line to
-:code:`franka_description/robots/panda_arm_hand.urdf.xacro`:
+:code:`franka_description/robots/panda_arm.urdf.xacro`:
 
 .. code-block:: xml
 
@@ -306,7 +306,7 @@ with :code:`<param name="robot_description" textfile="$(arg urdf_path)" />` and 
 
 .. code-block:: xml
 
-    <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
+    <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'"/>
 
 
 With this adjustment we are using :code:`xacro` executable that compiles :code:`xacro` files into URDF files.

--- a/doc/planning_scene/launch/planning_scene_tutorial.launch
+++ b/doc/planning_scene/launch/planning_scene_tutorial.launch
@@ -1,6 +1,6 @@
 <launch>
   <!-- send Panda urdf to parameter server -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'" />
 
   <include file="$(find panda_moveit_config)/launch/planning_context.launch"/>
 

--- a/doc/planning_scene/launch/planning_scene_tutorial.launch
+++ b/doc/planning_scene/launch/planning_scene_tutorial.launch
@@ -1,6 +1,6 @@
 <launch>
   <!-- send Panda urdf to parameter server -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro' hand:=true" />
 
   <include file="$(find panda_moveit_config)/launch/planning_context.launch"/>
 

--- a/doc/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/setup_assistant/setup_assistant_tutorial.rst
@@ -49,10 +49,10 @@ Step 1: Start
 
 .. image:: setup_assistant_start.png
 
-* Click on the browse button and navigate to the *panda_arm_hand.urdf.xacro* file
+* Click on the browse button and navigate to the *panda_arm.urdf.xacro* file
   installed when you installed the Franka package above. (This file
   gets installed in
-  /opt/ros/noetic/share/franka_description/robots/panda_arm_hand.urdf.xacro on Ubuntu
+  /opt/ros/noetic/share/franka_description/robots/panda_arm.urdf.xacro on Ubuntu
   with ROS Noetic.)  Choose that file and then click *Load Files*. The
   Setup Assistant will load the files (this might take a few seconds)
   and present you with this screen:

--- a/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
+++ b/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- load URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro' hand:=true" />
 
   <!-- load SRDF -->
   <param name="robot_description_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'"/>

--- a/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
+++ b/doc/visualizing_collisions/launch/visualizing_collisions_tutorial.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- load URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm_hand.urdf.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(find franka_description)/robots/panda_arm.urdf.xacro'"/>
 
   <!-- load SRDF -->
   <param name="robot_description_semantic" command="$(find xacro)/xacro '$(find panda_moveit_config)/config/panda_arm_hand.srdf.xacro'"/>


### PR DESCRIPTION
urdf file name corrected to avoid launch errors. As in franka description the file was name differently and lauch file in moveit_tutorial was giving error as result.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
