### PR TITLE
Extends information on collision objects in python interface

### DIFF
--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -342,7 +342,7 @@ class MoveGroupPythonInterfaceTutorial(object):
         ##
         ## Ensuring Collision Updates Are Received
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        ## If the Python nodewas just created and did not connect to other nodes yet, or 
+        ## If the Python node was just created and did not connect to other nodes yet, or 
         ## dies before publishing a collision object update message, the message
         ## could get lost and the box will not appear. To ensure that the updates are
         ## made, we wait until we see the changes reflected in the

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -342,7 +342,7 @@ class MoveGroupPythonInterfaceTutorial(object):
         ##
         ## Ensuring Collision Updates Are Received
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        ## If the Python node was just created and did not connect to other nodes yet, or 
+        ## If the Python node was just created and did not connect to other nodes yet, or
         ## dies before publishing a collision object update message, the message
         ## could get lost and the box will not appear. To ensure that the updates are
         ## made, we wait until we see the changes reflected in the

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -342,8 +342,8 @@ class MoveGroupPythonInterfaceTutorial(object):
         ##
         ## Ensuring Collision Updates Are Received
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        ## If the Python node was just created and did not connect to other nodes yet, or
-        ## dies before publishing a collision object update message, the message
+        ## If the Python node was just created (https://github.com/ros/ros_comm/issues/176),
+        ## or dies before actually publishing the scene update message, the message
         ## could get lost and the box will not appear. To ensure that the updates are
         ## made, we wait until we see the changes reflected in the
         ## ``get_attached_objects()`` and ``get_known_object_names()`` lists.

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -350,8 +350,8 @@ class MoveGroupPythonInterfaceTutorial(object):
         ## For the purpose of this tutorial, we call this function after adding,
         ## removing, attaching or detaching an object in the planning scene. We then wait
         ## until the updates have been made or ``timeout`` seconds have passed.
-        ## An alternative to this would be to set the ``synchronous`` parameter of the
-        ## planning scene interface constructor to ``True``.
+        ## To avoid waiting for scene updates like this at all, initialize the
+        ## planning scene interface with  ``synchronous = True``.
         start = rospy.get_time()
         seconds = rospy.get_time()
         while (seconds - start < timeout) and not rospy.is_shutdown():

--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -342,13 +342,16 @@ class MoveGroupPythonInterfaceTutorial(object):
         ##
         ## Ensuring Collision Updates Are Received
         ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        ## If the Python node dies before publishing a collision object update message, the message
+        ## If the Python nodewas just created and did not connect to other nodes yet, or 
+        ## dies before publishing a collision object update message, the message
         ## could get lost and the box will not appear. To ensure that the updates are
         ## made, we wait until we see the changes reflected in the
         ## ``get_attached_objects()`` and ``get_known_object_names()`` lists.
         ## For the purpose of this tutorial, we call this function after adding,
         ## removing, attaching or detaching an object in the planning scene. We then wait
-        ## until the updates have been made or ``timeout`` seconds have passed
+        ## until the updates have been made or ``timeout`` seconds have passed.
+        ## An alternative to this would be to set the ``synchronous`` parameter of the
+        ## planning scene interface constructor to ``True``.
         start = rospy.get_time()
         seconds = rospy.get_time()
         while (seconds - start < timeout) and not rospy.is_shutdown():


### PR DESCRIPTION
### Description

Added the info that collision objects might also not be committed properly if the node creating them is only recently created and that using the planning scene interface in synchronous mode can also solve the issue.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
