### PR TITLE
Clearing up return type of move_group.go()

### DIFF
--- a/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
+++ b/doc/move_group_python_interface/scripts/move_group_python_interface_tutorial.py
@@ -229,11 +229,12 @@ class MoveGroupPythonInterfaceTutorial(object):
         move_group.set_pose_target(pose_goal)
 
         ## Now, we call the planner to compute the plan and execute it.
-        plan = move_group.go(wait=True)
+        # `go()` returns a boolean indicating whether the planning and execution was successful.
+        success = move_group.go(wait=True)
         # Calling `stop()` ensures that there is no residual movement
         move_group.stop()
         # It is always good to clear your targets after planning with poses.
-        # Note: there is no equivalent function for clear_joint_value_targets()
+        # Note: there is no equivalent function for clear_joint_value_targets().
         move_group.clear_pose_targets()
 
         ## END_SUB_TUTORIAL


### PR DESCRIPTION

### Description

The variable name 'plan' was confusing, so I changed it to 'success' and explained it.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

