### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,6 @@ jobs:
 
       - name: industrial_ci
         uses: ros-industrial/industrial_ci@master
-        env: ${{ matrix.env }}
 
       - name: upload test artifacts (on failure)
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,3 +26,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/html
+        force_orphan: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,16 +11,14 @@ jobs:
   default:
     name: Build + Test + Deploy Website
     runs-on: ubuntu-latest
+    container: ros:noetic-ros-base
     steps:
     - uses: actions/checkout@v2
-    - uses: ros-tooling/setup-ros@v0.2
-      with:
-        required-ros-distributions: noetic
-    - uses: actions/setup-python@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7'
-    - name: "Build+Test: Run htmlproofer.sh"
+    - name: "Install ruby"
+      run: |
+        apt-get update -q
+        apt-get install -q -y ruby-dev libffi-dev build-essential git
+    - name: "Run htmlproofer.sh"
       run: ./htmlproofer.sh
     - name: Deploy
       if: ${{ success() && github.event_name == 'push'}}

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -7,12 +7,12 @@ export REPOSITORY_NAME=${PWD##*/}
 echo "Testing branch ${GITHUB_BASE_REF:-$GITHUB_HEAD_REF} of $REPOSITORY_NAME"
 
 # Install htmlpoofer
-gem update --system
+sudo gem update --system --no-document
 gem --version
-gem install html-proofer -v 3.19.4 # newer 4.x requires different cmdline options
+sudo gem install html-proofer -v 3.19.4 # newer 4.x requires different cmdline options
 # Install ROS's version of sphinx
-sudo apt-get -qq install "ros-noetic-rosdoc-lite"
-source "/opt/ros/noetic/setup.bash"
+sudo apt-get -qq install "ros-$ROS_DISTRO-rosdoc-lite"
+source "/opt/ros/$ROS_DISTRO/setup.bash"
 
 # Test build with non-ROS wrapped Sphinx command to allow warnings and errors to be caught
 sphinx-build -W -b html . native_build
@@ -20,7 +20,7 @@ sphinx-build -W -b html . native_build
 rosdoc_lite -o build .
 
 # Run HTML tests on generated build output to check for 404 errors, etc
-test "$TRAVIS_PULL_REQUEST" == false || URL_SWAP="--url-swap https\://github.com/ros-planning/moveit_tutorials/blob/master/:file\://$PWD/build/html/"
+URL_SWAP="--url-swap https\://github.com/ros-planning/moveit_tutorials/blob/master/:file\://$PWD/build/html/"
 htmlproofer ./build --only-4xx --check-html --file-ignore ./build/html/genindex.html,./build/html/search.html --alt-ignore '/.*/' --url-ignore '#' $URL_SWAP
 
 # Tell GitHub Pages (on deploy) to bypass Jekyll processing


### PR DESCRIPTION
@tylerjw, the 2nd commit introduces [`force-orphan: true`](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan) to keep the latest gh-pages commit only. I remember that you were looking for this feature for moveit2_tutorials too.