### PR TITLE
Remove slash

### DIFF
--- a/doc/pilz_industrial_motion_planner/pilz_industrial_motion_planner.rst
+++ b/doc/pilz_industrial_motion_planner/pilz_industrial_motion_planner.rst
@@ -70,7 +70,7 @@ are explained below.
 For a general introduction on how to fill a ``MotionPlanRequest`` see
 :ref:`move_group_interface-planning-to-pose-goal`.
 
-You can specify "PTP", "LIN" or "CIRC" as the ``planner\_id``of the ``MotionPlanRequest``.
+You can specify "PTP", "LIN" or "CIRC" as the ``planner_id``of the ``MotionPlanRequest``.
 
 The PTP motion command
 ----------------------


### PR DESCRIPTION
### Description

Fixed the wrong format of text in the documentation by removing the slash.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
