### PR TITLE
Adding AIT*, BIT* and ABIT* to listed OMPL planners.

### DIFF
--- a/doc/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/ompl_interface/ompl_interface_tutorial.rst
@@ -65,9 +65,9 @@ Several planners that are part of the OMPL planning library are capable of optim
 * SPARS
 * SPARS2
 * Transition-based RRT (T-RRT)
-* AIT*
-* BIT*
-* ABIT*
+* Adaptively Informed Tree (AIT*)
+* Batched Informed Tree (BIT*)
+* Advanced Batched Informed Tree (ABIT*)
 
 OMPL also provides a meta-optimization algorithm called AnytimePathShortening, which repeatedly runs several planners in parallel interleaved with path shortcutting and path hybridization, two techniques that locally optimize a solution path. Although not *proven* optimal, it is often an effective strategy in practice to obtaining near-optimal solution paths.
 
@@ -76,7 +76,6 @@ Other optimal planners in OMPL but not exposed in MoveIt yet:
 * RRT#
 * RRTX
 * Informed RRT*
-* Batch Informed Trees (BIT*)
 * Sparse Stable RRT
 * CForest
 

--- a/doc/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/ompl_interface/ompl_interface_tutorial.rst
@@ -65,6 +65,9 @@ Several planners that are part of the OMPL planning library are capable of optim
 * SPARS
 * SPARS2
 * Transition-based RRT (T-RRT)
+* AIT*
+* BIT*
+* ABIT*
 
 OMPL also provides a meta-optimization algorithm called AnytimePathShortening, which repeatedly runs several planners in parallel interleaved with path shortcutting and path hybridization, two techniques that locally optimize a solution path. Although not *proven* optimal, it is often an effective strategy in practice to obtaining near-optimal solution paths.
 


### PR DESCRIPTION
### Description

Adding AIT*, BIT* and ABIT* to list of OMPL planners.
This PR is related to the [moveit PR#3347](https://github.com/ros-planning/moveit/pull/3347) and should only get merged after PR#3347 is merged.
