### PR TITLE
panda_moveit_config already clones in previous steps

### DIFF
--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -43,8 +43,7 @@ Within your `catkin <http://wiki.ros.org/catkin>`_ workspace, download the tutor
 
   cd ~/ws_moveit/src
   git clone https://github.com/ros-planning/moveit_tutorials.git -b master
-  git clone https://github.com/ros-planning/panda_moveit_config.git -b noetic-devel
-
+  
 .. note:: For now we will use a pre-generated ``panda_moveit_config`` package but later we will learn how to make our own in the `MoveIt Setup Assistant tutorial <../setup_assistant/setup_assistant_tutorial.html>`_.
 
 Build your Catkin Workspace


### PR DESCRIPTION
### Description

panda_moveit_config is already cloned with wstool in the previous step and not removed. Cloning it again gives an error.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
