### PR TITLE
Remove redundant closing tag

### DIFF
--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -11,7 +11,6 @@ This tutorial shows how to send real-time servo commands to a ROS-enabled robot.
         type="application/x-shockwave-flash" allowscriptaccess="always"
         allowfullscreen="true" width="700"
         height="385">
-      </embed>
     </object>
 
 Getting Started

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -10,7 +10,7 @@ This tutorial shows how to send real-time servo commands to a ROS-enabled robot.
         src="https://www.youtube.com/v/8sOucNloJeI&hl=en_US&fs=1&rel=0"
         type="application/x-shockwave-flash" allowscriptaccess="always"
         allowfullscreen="true" width="700"
-        height="385">
+        height="385"/>
     </object>
 
 Getting Started


### PR DESCRIPTION
Fixes the html error reported in #779.
`<embed>` is an empty element and must not have an end tag (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed#technical_summary)