### PR TITLE
Update realtime_servo_tutorial.rst

### DIFF
--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -129,6 +129,7 @@ There is a Python integration test in ``test/integration``. Run it by:
 
   roscd moveit_servo
   catkin run_tests --this
+
 Debug Tips
--------------------
+---------------
 Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller`` or ``joint_group_velocity_controller`` should be ``running``.

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -131,4 +131,4 @@ There is a Python integration test in ``test/integration``. Run it by:
   catkin run_tests --this
 Debug Tips
 -------------------
-Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller``(tested) or ``joint_group_velocity_controller``(I think, haven't tested personally this one though) should be ``running``
+Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller`` or ``joint_group_velocity_controller`` should be ``running``.

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -19,7 +19,7 @@ This tutorial demonstrates the servo node with a UR5 Gazebo simulation. If you h
 
 Clone `universal_robot melodic-devel branch <https://github.com/ros-industrial/universal_robot.git>`_ into the same catkin workspace from `Getting Started`:
 
-**NOTE: Please stick to older version of Universal Robot Github (1.2.7 ) as newer versions (1.3.x) are incompatible with the servo tutorial.** (`Src <https://github.com/ros-planning/moveit_tutorials/commit/f9fba77cd6cab31c9ae360bbaca3896a6acef446>`_)
+**NOTE: Please stick to older version of Universal Robot Github (1.2.7 ) as newer versions (1.3.x) are incompatible with the servo tutorial.**
 ::
 
     cd ~/ws_moveit/src

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -129,7 +129,6 @@ There is a Python integration test in ``test/integration``. Run it by:
 
   roscd moveit_servo
   catkin run_tests --this
- 
 Debug Tips
 -------------------
 Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller``(tested) or ``joint_group_velocity_controller``(I think, haven't tested personally this one though) should be ``running``

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -132,5 +132,5 @@ There is a Python integration test in ``test/integration``. Run it by:
   
 Debug Tips
 -------------------
-Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller`` should be ``running``
+Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller``(tested) or ``joint_group_velocity_controller``(I think, haven't tested personally this one though) should be ``running``
 

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -133,4 +133,3 @@ There is a Python integration test in ``test/integration``. Run it by:
 Debug Tips
 -------------------
 Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller``(tested) or ``joint_group_velocity_controller``(I think, haven't tested personally this one though) should be ``running``
-

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -129,7 +129,7 @@ There is a Python integration test in ``test/integration``. Run it by:
 
   roscd moveit_servo
   catkin run_tests --this
-  
+ 
 Debug Tips
 -------------------
 Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller``(tested) or ``joint_group_velocity_controller``(I think, haven't tested personally this one though) should be ``running``

--- a/doc/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/realtime_servo/realtime_servo_tutorial.rst
@@ -17,7 +17,10 @@ Getting Started
 ---------------
 This tutorial demonstrates the servo node with a UR5 Gazebo simulation. If you haven't already done so, make sure you've completed the steps in `Getting Started <../getting_started/getting_started.html>`_.
 
-Clone `universal_robot melodic-devel branch <https://github.com/ros-industrial/universal_robot.git>`_ into the same catkin workspace from `Getting Started`: ::
+Clone `universal_robot melodic-devel branch <https://github.com/ros-industrial/universal_robot.git>`_ into the same catkin workspace from `Getting Started`:
+
+**NOTE: Please stick to older version of Universal Robot Github (1.2.7 ) as newer versions (1.3.x) are incompatible with the servo tutorial.** (`Src <https://github.com/ros-planning/moveit_tutorials/commit/f9fba77cd6cab31c9ae360bbaca3896a6acef446>`_)
+::
 
     cd ~/ws_moveit/src
 
@@ -126,3 +129,8 @@ There is a Python integration test in ``test/integration``. Run it by:
 
   roscd moveit_servo
   catkin run_tests --this
+  
+Debug Tips
+-------------------
+Do run either ``rosservice call /controller_manager/list_controllers`` or ``rosrun controller_manager controller_manager list``. For moveit_servo to be working, ``joint_group_position_controller`` should be ``running``
+


### PR DESCRIPTION
### Description

Although, the code suggests cloning the old version of UR's repo but it does not clearly mention it in words. I did not clone the old version because I already had the latest version and the tutorial didn't work for me for now obvious reasons. So, I am adding a note in bold so that no one else does the same mistake as mine and don't waste 2 days like me. I also added a debug tip to see when one should expect the tutorial to work.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
