### PR TITLE
No slash in links

### DIFF
--- a/doc/multiple_robot_arms/multiple_robot_arms_tutorial.rst
+++ b/doc/multiple_robot_arms/multiple_robot_arms_tutorial.rst
@@ -49,7 +49,7 @@ Our multiple arms model has ``right_arm`` and ``left_arm`` robots. Each arm is e
 
 Notes:
 
-1. Two arguments ``right_arm`` and ``left_arm`` are defined as prefixes to differentiate the arms and hands names.
+1. Two arguments ``right_arm`` and ``left_arm`` are defined as prefixes to differentiate the arms and hands names. Be careful not to use any of the following characters in the prefixes: ``-``, ``[``, ``]``, ``(``, ``)``, ``/``.
 
 2. The arms and hands models are loaded from the ``franka_description`` package, which is installed as a dependency of the ``panda_moveit_config`` package. Ensure the ``franka_description`` package is installed in your ROS environment.
 

--- a/doc/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/ompl_interface/ompl_interface_tutorial.rst
@@ -65,9 +65,9 @@ Several planners that are part of the OMPL planning library are capable of optim
 * SPARS
 * SPARS2
 * Transition-based RRT (T-RRT)
-* AIT*
-* BIT*
-* ABIT*
+* Adaptively Informed Tree (AIT*)
+* Batched Informed Tree (BIT*)
+* Advanced Batched Informed Tree (ABIT*)
 
 OMPL also provides a meta-optimization algorithm called AnytimePathShortening, which repeatedly runs several planners in parallel interleaved with path shortcutting and path hybridization, two techniques that locally optimize a solution path. Although not *proven* optimal, it is often an effective strategy in practice to obtaining near-optimal solution paths.
 
@@ -76,7 +76,6 @@ Other optimal planners in OMPL but not exposed in MoveIt yet:
 * RRT#
 * RRTX
 * Informed RRT*
-* Batch Informed Trees (BIT*)
 * Sparse Stable RRT
 * CForest
 

--- a/doc/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/ompl_interface/ompl_interface_tutorial.rst
@@ -65,6 +65,9 @@ Several planners that are part of the OMPL planning library are capable of optim
 * SPARS
 * SPARS2
 * Transition-based RRT (T-RRT)
+* AIT*
+* BIT*
+* ABIT*
 
 OMPL also provides a meta-optimization algorithm called AnytimePathShortening, which repeatedly runs several planners in parallel interleaved with path shortcutting and path hybridization, two techniques that locally optimize a solution path. Although not *proven* optimal, it is often an effective strategy in practice to obtaining near-optimal solution paths.
 

--- a/doc/urdf_srdf/urdf_srdf_tutorial.rst
+++ b/doc/urdf_srdf/urdf_srdf_tutorial.rst
@@ -18,7 +18,7 @@ This section contains a set of tips on making sure that the URDF that you genera
 
 Special Characters in Joint Names
 """""""""""""""""""""""""""""""""
-Joint names should not contain any of the following special characters: ``-``, ``[``, ``]``, ``(``, ``)``. 
+Joint names should not contain any of the following special characters: ``-``, ``[``, ``]``, ``(``, ``)``.
 
 We hope to be able to get rid of these restrictions on the joint names soon.
 

--- a/doc/urdf_srdf/urdf_srdf_tutorial.rst
+++ b/doc/urdf_srdf/urdf_srdf_tutorial.rst
@@ -18,9 +18,14 @@ This section contains a set of tips on making sure that the URDF that you genera
 
 Special Characters in Joint Names
 """""""""""""""""""""""""""""""""
-Joint names should not contain any of the following special characters: -,[,],(,),
+Joint names should not contain any of the following special characters: ``-``, ``[``, ``]``, ``(``, ``)``. 
 
 We hope to be able to get rid of these restrictions on the joint names soon.
+
+Special Characters in Link Names
+"""""""""""""""""""""""""""""""""
+Link names should not contain any of the following characters:  ``-``, ``[``, ``]``, ``(``, ``)``. 
+Link names also should not include any ``/`` character, as Moveit will interpret any such slash as a separator for a subframe (see `Subframes <https://ros-planning.github.io/moveit_tutorials/doc/subframes/subframes_tutorial.html#/>`_). We suggest to use ``_``, ``:``, or ``\`` instead.
 
 Safety Limits
 """""""""""""

--- a/doc/urdf_srdf/urdf_srdf_tutorial.rst
+++ b/doc/urdf_srdf/urdf_srdf_tutorial.rst
@@ -24,7 +24,7 @@ We hope to be able to get rid of these restrictions on the joint names soon.
 
 Special Characters in Link Names
 """""""""""""""""""""""""""""""""
-Link names should not contain any of the following characters:  ``-``, ``[``, ``]``, ``(``, ``)``. 
+Link names should not contain any of the following characters:  ``-``, ``[``, ``]``, ``(``, ``)``.
 Link names also should not include any ``/`` character, as Moveit will interpret any such slash as a separator for a subframe (see `Subframes <https://ros-planning.github.io/moveit_tutorials/doc/subframes/subframes_tutorial.html#/>`_). We suggest to use ``_``, ``:``, or ``\`` instead.
 
 Safety Limits


### PR DESCRIPTION
### Description

Following [Issue 3514](https://github.com/ros-planning/moveit/issues/3514) on the MoveIt repo, I suggest to explicitly list the characters one shouldn't use in a link name, including the `/` used for subframes.

The PR amends the pages that mention link names and prefixes (i.e. `urdf_srdf_tutorial.rst` and `multiple_robot_arms_tutorial.rst`). It also slightly improves the formatting of the list of characters to avoid for the sake of readability.