### PR TITLE
Replace all moveit.ros.org to moveit.ai

### DIFF
--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -134,10 +134,10 @@
 
         <div class="header-override">
           <p>
-            <a href="http://moveit.ros.org">MoveIt! Website</a><br/>
-            <a href="http://moveit.ros.org/blog">Blog</a>
+            <a href="http://moveit.ai">MoveIt! Website</a><br/>
+            <a href="http://moveit.ai/blog">Blog</a>
           </p>
-          <a href="http://moveit.ros.org">
+          <a href="http://moveit.ai">
             <img src="{{ pathto('_static/logo.png', 1) }}"/>
           </a>
         </div>

--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ extlinks = {'codedir': ('https://github.com/ros-planning/moveit_tutorials/tree/i
             'kinematic_constraints': ('http://docs.ros.org/indigo/api/moveit_core/html/classkinematic__constraints_1_1%s.html', ''),
             'moveit_core_files': ('http://docs.ros.org/indigo/api/moveit_core/html/%s.html', ''),
             'move_group_interface': ('http://docs.ros.org/indigo/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1%s.html', ''),
-            'moveit_website': ('http://moveit.ros.org/%s/', '')}
+            'moveit_website': ('http://moveit.ai/%s/', '')}
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'MoveItDocumentation'

--- a/doc/benchmarking_tutorial.rst
+++ b/doc/benchmarking_tutorial.rst
@@ -3,7 +3,7 @@ Benchmarking Tutorial
 
 .. note:: This is the new benchmarking method only available in ROS Kinetic, onward. Documentation is lacking for the previous benchmarking tutorial for Jade and earlier.
 
-.. note:: To use this benchmarking method, you will need to download and install the ROS Warehouse plugin. Currently this is not available from debians and requires a source install for at least some aspects. For source instructions, see `this page <http://moveit.ros.org/install/source/dependencies/>`_
+.. note:: To use this benchmarking method, you will need to download and install the ROS Warehouse plugin. Currently this is not available from debians and requires a source install for at least some aspects. For source instructions, see `this page <http://moveit.ai/install/source/dependencies/>`_
 
 The `benchmarking package <https://github.com/ros-planning/moveit/tree/kinetic-devel/moveit_ros/benchmarks>`_ provides methods to benchmark motion planning algorithms and aggregate/plot statistics using the OMPL Planner Arena.
 The example below demonstrates how the benchmarking can be run for a Fanuc M-10iA.

--- a/doc/pr2_tutorials/kinematics/src/doc/kinematic_model_tutorial.rst
+++ b/doc/pr2_tutorials/kinematics/src/doc/kinematic_model_tutorial.rst
@@ -18,7 +18,7 @@ The entire code can be seen :codedir:`here in the moveit_pr2 github project<kine
 
 Compiling the code
 ^^^^^^^^^^^^^^^^^^
-Follow the `instructions for compiling code from source <http://moveit.ros.org/install/>`_.
+Follow the `instructions for compiling code from source <http://moveit.ai/install/>`_.
 
 The launch file
 ^^^^^^^^^^^^^^^

--- a/doc/pr2_tutorials/planning/src/doc/motion_planning_api_tutorial.rst
+++ b/doc/pr2_tutorials/planning/src/doc/motion_planning_api_tutorial.rst
@@ -13,7 +13,7 @@ The entire code can be seen :codedir:`here in the moveit_pr2 github project<plan
 
 Compiling the code
 ^^^^^^^^^^^^^^^^^^
-Follow the `instructions for compiling code from source <http://moveit.ros.org/install/>`_.
+Follow the `instructions for compiling code from source <http://moveit.ai/install/>`_.
 
 The launch file
 ^^^^^^^^^^^^^^^

--- a/doc/pr2_tutorials/planning/src/doc/move_group_interface_tutorial.rst
+++ b/doc/pr2_tutorials/planning/src/doc/move_group_interface_tutorial.rst
@@ -11,7 +11,7 @@ The entire code can be seen :codedir:`here in the moveit_pr2 github project<plan
 
 Compiling the code
 ^^^^^^^^^^^^^^^^^^
-Follow the `instructions for compiling code from source <http://moveit.ros.org/install/>`_.
+Follow the `instructions for compiling code from source <http://moveit.ai/install/>`_.
 
 The launch file
 ^^^^^^^^^^^^^^^

--- a/doc/pr2_tutorials/planning/src/doc/planning_pipeline_tutorial.rst
+++ b/doc/pr2_tutorials/planning/src/doc/planning_pipeline_tutorial.rst
@@ -17,7 +17,7 @@ The entire code can be seen :codedir:`here in the moveit_pr2 github project<plan
 
 Compiling the code
 ^^^^^^^^^^^^^^^^^^
-Follow the `instructions for compiling code from source <http://moveit.ros.org/install/>`_.
+Follow the `instructions for compiling code from source <http://moveit.ai/install/>`_.
 
 The launch file
 ^^^^^^^^^^^^^^^

--- a/doc/pr2_tutorials/planning/src/doc/planning_scene_ros_api_tutorial.rst
+++ b/doc/pr2_tutorials/planning/src/doc/planning_scene_ros_api_tutorial.rst
@@ -15,7 +15,7 @@ The entire code can be seen :codedir:`here in the moveit_pr2 github project<plan
 
 Compiling the code
 ^^^^^^^^^^^^^^^^^^
-Follow the `instructions for compiling code from source <http://moveit.ros.org/install/>`_.
+Follow the `instructions for compiling code from source <http://moveit.ai/install/>`_.
 
 The launch file
 ^^^^^^^^^^^^^^^

--- a/doc/pr2_tutorials/planning/src/doc/planning_scene_tutorial.rst
+++ b/doc/pr2_tutorials/planning/src/doc/planning_scene_tutorial.rst
@@ -13,7 +13,7 @@ The entire code can be seen :codedir:`here in the moveit_pr2 github project<plan
 
 Compiling the code
 ^^^^^^^^^^^^^^^^^^
-Follow the `instructions for compiling code from source <http://moveit.ros.org/install/>`_.
+Follow the `instructions for compiling code from source <http://moveit.ai/install/>`_.
 
 The launch file
 ^^^^^^^^^^^^^^^

--- a/index.rst
+++ b/index.rst
@@ -1,11 +1,11 @@
 MoveIt! Tutorials
 =================
 
-These tutorials will run you through how to use MoveIt! with your robot. It is assumed that you have already configured MoveIt! for your robot - check the `list of robots running MoveIt! <http://moveit.ros.org/robots/>`_ to see whether MoveIt! is already available for your robot. Otherwise, skip to the tutorial on Setting up MoveIt! for your robot. If you just want to test MoveIt!, use the PR2 as your quick-start robot.
+These tutorials will run you through how to use MoveIt! with your robot. It is assumed that you have already configured MoveIt! for your robot - check the `list of robots running MoveIt! <http://moveit.ai/robots/>`_ to see whether MoveIt! is already available for your robot. Otherwise, skip to the tutorial on Setting up MoveIt! for your robot. If you just want to test MoveIt!, use the PR2 as your quick-start robot.
 
 .. note:: All tutorials referencing the PR2 have only been tested with ROS Indigo but likely work with ROS Jade. See `issue <https://github.com/ros-planning/moveit/issues/110>`_ for more information.
 
-Before beginning the tutorials it is recommended that you read through the `Concepts <http://moveit.ros.org/documentation/concepts/>`_ page to get a general overview of how MoveIt! works. This page runs through some of the basic concepts underlying the MoveIt! system architecture, interfaces and usage.
+Before beginning the tutorials it is recommended that you read through the `Concepts <http://moveit.ai/documentation/concepts/>`_ page to get a general overview of how MoveIt! works. This page runs through some of the basic concepts underlying the MoveIt! system architecture, interfaces and usage.
 
 Beginner
 --------
@@ -41,7 +41,7 @@ This set of advanced tutorials is meant for developers who are using MoveIt!’s
 Integration with New Robot
 --------------------------
 
-Before attempting to integrate a new robot with MoveIt!, check whether your robot has already been setup (see the `list of robots running MoveIt! <http://moveit.ros.org/robots/>`_). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt! (and share your results on the MoveIt! mailing list)
+Before attempting to integrate a new robot with MoveIt!, check whether your robot has already been setup (see the `list of robots running MoveIt! <http://moveit.ai/robots/>`_). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt! (and share your results on the MoveIt! mailing list)
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
The ROS.org team is turning of moveit.ros.org, which redirects to moveit.ai currently. We need to find all instances of moveit.ros.org and make PRs to replace them.

@gbiggs is pushing to turn off moveit.ros.rog per this post from a year ago

https://discourse.openrobotics.org/t/move-of-nav2-and-moveit-repositories-at-github/37450