### PR TITLE
Replace all moveit.ros.org to moveit.ai

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Please explain the changes you made, including a reference to the related issue if applicable
 
 ### Checklist
-- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
+- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ai/documentation/contributing/code)
 - [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
 
 [//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We rely on the community to keep these tutorials up to date and bug free. If you
 
 **Code Formatting**
 
-* These tutorials use the same [style guidelines](http://moveit.ros.org/documentation/contributing/code/) as the MoveIt! project. When modifying or adding to these tutorials, it is required that code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code/).
+* These tutorials use the same [style guidelines](http://moveit.ai/documentation/contributing/code/) as the MoveIt! project. When modifying or adding to these tutorials, it is required that code is auto formatted using [clang-format](http://moveit.ai/documentation/contributing/code/).
 * Tutorials should exemplify best coding practices. If a contribution wouldn't pass review in the MoveIt! project, then it shouldn't pass review in the tutorials.
 * Relevant code should be included and explained using the ``.. tutorial-formatter::`` tag.
 * Irrelevant code should be excluded from the generated html using the ``BEGIN_TUTORIAL``, ``END_TUTORIAL``, ``BEGIN_SUB_TUTORIAL``, and ``END_SUB_TUTORIAL`` tags.

--- a/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -13,7 +13,7 @@
         {% endif %}
       {% endif %}
     </li>
-    <li><a href="http://moveit.ros.org">MoveIt</a> &raquo;</li>
+    <li><a href="http://moveit.ai">MoveIt</a> &raquo;</li>
     <li><a href="{{ pathto(master_doc) }}">Tutorials</a> &raquo;</li>
       {% for doc in parents %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>

--- a/_themes/sphinx_rtd_theme/layout.html
+++ b/_themes/sphinx_rtd_theme/layout.html
@@ -98,7 +98,7 @@
       <div class="wy-side-nav-search">
         {% block sidebartitle %}
 
-        <a href="http://moveit.ros.org">
+        <a href="http://moveit.ai">
           <img src="{{ pathto('_static/logo.png', 1) }}"/>
         </a>
 

--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ extlinks = {'codedir': ('https://github.com/' + html_context["github_user"] + '/
             'kinematic_constraints': ('http://docs.ros.org/' + ros_distro + '/api/moveit_core/html/cpp/classkinematic__constraints_1_1%s.html', ''),
             'moveit_core_files': ('http://docs.ros.org/' + ros_distro + '/api/moveit_core/html/cpp/%s.html', ''),
             'move_group_interface': ('http://docs.ros.org/' + ros_distro + '/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1%s.html', ''),
-            'moveit_website': ('http://moveit.ros.org/%s/', '')}
+            'moveit_website': ('http://moveit.ai/%s/', '')}
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'MoveItDocumentation'

--- a/doc/benchmarking/benchmarking_tutorial.rst
+++ b/doc/benchmarking/benchmarking_tutorial.rst
@@ -4,7 +4,7 @@
 Benchmarking
 =====================
 
-.. note:: To use this benchmarking method, you will need to download and install the ROS Warehouse plugin. Currently this is not available from Debians and requires a source install for at least some aspects. For source instructions, see `this page <http://moveit.ros.org/install/source/dependencies/>`_
+.. note:: To use this benchmarking method, you will need to download and install the ROS Warehouse plugin. Currently this is not available from Debians and requires a source install for at least some aspects. For source instructions, see `this page <http://moveit.ai/install/source/dependencies/>`_
 
 Getting Started
 ---------------

--- a/doc/getting_started/getting_started.rst
+++ b/doc/getting_started/getting_started.rst
@@ -22,7 +22,7 @@ The simplest way to install MoveIt is from pre-built binaries (Debian): ::
 
   sudo apt install ros-melodic-moveit
 
-Advanced users might want to `install MoveIt from source <http://moveit.ros.org/install/source/>`_.
+Advanced users might want to `install MoveIt from source <http://moveit.ai/install/source/>`_.
 If you want to build your own MoveIt fork, replace the repository uri in the .rosinstall file with your own.
 
 Create A Catkin Workspace

--- a/doc/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/ompl_interface/ompl_interface_tutorial.rst
@@ -106,4 +106,4 @@ You can adjust the amount of time MoveIt spends on smoothing by increasing the p
 
 Although not currently exposed at the top levels of MoveIt (TODO), more smoothing can be accomplished by setting the simplification duration to 0 (unlimited) in ``model_based_planning_context.cpp``. This will enable OMPL's ``simplifyMax()`` function.
 
-Besides the internal OMPL smoothers, recent efforts have been made to do post-proccessing with STOMP/CHOMP. See `this blog post <http://moveit.ros.org/moveit!/ros/2018/10/25/gsoc-motion-planning-support.html>`_.
+Besides the internal OMPL smoothers, recent efforts have been made to do post-proccessing with STOMP/CHOMP. See `this blog post <http://moveit.ai/moveit!/ros/2018/10/25/gsoc-motion-planning-support.html>`_.

--- a/doc/planning_adapters/planning_adapters_tutorial.rst
+++ b/doc/planning_adapters/planning_adapters_tutorial.rst
@@ -21,7 +21,7 @@ As you add and remove packages from your workspace you will need to clean your w
   cd ~/ws_moveit/src
   catkin clean
 
-Now follow the instructions on the MoveIt homepage for `installing MoveIt Melodic from source <http://moveit.ros.org/install/source/>`_. Note that you can skip the **Prerequisites** section since you should already have a Catkin workspace.
+Now follow the instructions on the MoveIt homepage for `installing MoveIt Melodic from source <http://moveit.ai/install/source/>`_. Note that you can skip the **Prerequisites** section since you should already have a Catkin workspace.
 
 Re-source the setup files: ::
 

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@ These tutorials will step you through using and learning the MoveIt Motion Plann
 .. image:: doc/quickstart_in_rviz/rviz_plugin_head.png
    :width: 700px
 
-In these tutorials, the Franka Emika Panda robot is used as a quick-start demo. Alternatively, you can easily use any robot that has already been configured to work with MoveIt - check the `list of robots running MoveIt <http://moveit.ros.org/robots/>`_ to see whether MoveIt is already available for your robot. Otherwise, you can setup MoveIt to work with your custom robot in the tutorial section "Integration with a New Robot", below.
+In these tutorials, the Franka Emika Panda robot is used as a quick-start demo. Alternatively, you can easily use any robot that has already been configured to work with MoveIt - check the `list of robots running MoveIt <http://moveit.ai/robots/>`_ to see whether MoveIt is already available for your robot. Otherwise, you can setup MoveIt to work with your custom robot in the tutorial section "Integration with a New Robot", below.
 
 Getting Started with MoveIt and RViz
 -------------------------------------
@@ -46,7 +46,7 @@ Building more complex applications with MoveIt often requires developers to dig 
 
 Integration with a New Robot
 ----------------------------
-Before attempting to integrate a new robot with MoveIt, check whether your robot has already been setup (see the `list of robots running MoveIt <http://moveit.ros.org/robots/>`_). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt (and share your results on the MoveIt mailing list)
+Before attempting to integrate a new robot with MoveIt, check whether your robot has already been setup (see the `list of robots running MoveIt <http://moveit.ai/robots/>`_). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt (and share your results on the MoveIt mailing list)
 
 .. toctree::
    :maxdepth: 1
@@ -86,7 +86,7 @@ Attribution
 -----------
 Major contributors to the MoveIt tutorials are listed in chronological order: Sachin Chitta, Dave Hershberger, Acorn Pooley, Dave Coleman, Michael Gorner, Francisco Suarez, Mike Lautman. Help us improve these docs and we'll be happy to include you here also!
 
-The tutorials had a major update in 2018 during a code sprint sponsored by Franka Emika in collaboration with PickNik (`Check out the blog post! <http://moveit.ros.org/moveit!/ros/2018/02/26/tutorials-documentation-codesprint.html>`_)
+The tutorials had a major update in 2018 during a code sprint sponsored by Franka Emika in collaboration with PickNik (`Check out the blog post! <http://moveit.ai/moveit!/ros/2018/02/26/tutorials-documentation-codesprint.html>`_)
 
 .. image:: ./_static/franka_logo.png
    :width: 300px


### PR DESCRIPTION
The ROS.org team is turning of moveit.ros.org, which redirects to moveit.ai currently. We need to find all instances of moveit.ros.org and make PRs to replace them.

@gbiggs is pushing to turn off moveit.ros.rog per this post from a year ago

https://discourse.openrobotics.org/t/move-of-nav2-and-moveit-repositories-at-github/37450